### PR TITLE
Fixed typo in path for 2nd configuration change

### DIFF
--- a/pages/wiki/bluetooth.hbs
+++ b/pages/wiki/bluetooth.hbs
@@ -19,7 +19,7 @@ layout: documentation
 </div>
 <p>In order to use BT PAN on AsteroidOS, you first need to modify the default image. Start by adding the following packages to the <i>IMAGE_INSTALL</i> variable of <i>asteroid/src/meta-asteroid/classes/asteroid-image.bbclass</i>:</p>
 <pre><code>bluez5-testtools bluez5-noinst-tools python-dbus connman-client</code></pre>
-<p>You also need to modify the bluez5’s main configuration in <i>asteroid/src/src/meta-asteroid/recipes-connectivity/bluez5/bluez5/main.conf</i> to</p>
+<p>You also need to modify the bluez5’s main configuration in <i>asteroid/src/meta-asteroid/recipes-connectivity/bluez5/bluez5/main.conf</i> to</p>
 <pre><code>[General]
 #ControllerMode = le
 DiscoverableTimeout = 180</code></pre>


### PR DESCRIPTION
The second configuration file that needs to be changed, `asteroid/src/meta-asteroid/recipes-connectivity/bluez5/bluez5/main.conf`, was incorrectly referenced in the guide with a duplicate `src` in the path. Super small typo, but figured it was a path and worthy of fixing in the real documentation.