### PR TITLE
Move Moto360 2nd gen and Sport to 'possible ports not supported yet'

### DIFF
--- a/pages/wiki/porting-status.hbs
+++ b/pages/wiki/porting-status.hbs
@@ -32,6 +32,8 @@ layout: documentation
 <li>Misfit Vapor</li>
 <li>Montblanc Summit</li>
 <li>Moto 360 (1st generation)</li>
+<li>Moto 360 (2nd generation)</li>
+<li>Moto 360 Sport</li>
 <li>Nixon Mission</li>
 <li>New Balance RunIQ Watch</li>
 <li>Samsung Gear S</li>
@@ -62,8 +64,6 @@ layout: documentation
 <li>Michael Kors Access Mesdames</li>
 <li>Michael Kors Dylan</li>
 <li>Michael Kors Sofie</li>
-<li>Moto 360 (2nd generation)</li>
-<li>Moto 360 Sport</li>
 <li>Movado Connect</li>
 <li>Polar M600</li>
 <li>Skagen Falster</li>


### PR DESCRIPTION
There is [this thread](https://forum.xda-developers.com/moto-360-2015/help/help-finding-pin-t3260871/page3) about the Moto 360 pinout.
I successfully connected it to a PC, booted the watch into Fastboot and dmesg showed this:
```
[  662.633549] usb 2-1.2: new high-speed USB device number 10 using ehci-pci
[  662.732596] usb 2-1.2: New USB device found, idVendor=22b8, idProduct=2e80
[  662.732603] usb 2-1.2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[  662.732607] usb 2-1.2: Product: Fastboot smelt NS
[  662.732610] usb 2-1.2: Manufacturer: Motorola Inc.
[  662.732613] usb 2-1.2: SerialNumber: <manually removed>
```

I haven't tried to access fastboot or boot AsteroidOS as I broke my screen cable in the process of dissasembling the watch. Turns out only the bottom case needs to removed in order to access the USB pins, so others don't have to risk breaking their watch.

Anyways in theory this makes it possible to port AsteroidOS to the Moto360 2nd gen. From [this teardown](https://imgur.com/a/yFb4s) the Moto 360 Sport seems to be the same hardware having the same pins.