### PR TITLE
Removed leftovers of google-analytics.com integration.

### DIFF
--- a/templates/includes/javascripts.hbs
+++ b/templates/includes/javascripts.hbs
@@ -8,16 +8,3 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/holder/2.2.0/holder.min.js"></script>
 <script src="{{ assets }}/js/application.js"></script>
 
-{{#if site.analytics.google_site_id}}
-<!-- Analytics
-================================================== -->
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', '{{site.analytics.google_site_id}}', 'auto');
-  ga('send', 'pageview');
-</script>
-{{/if}}


### PR DESCRIPTION
Follow up of #20 
This commit removes the leftovers of the google-analytics.com integration, which has been removed in commit 7e470818df2e0e8e7441d8797d63f8304729a6fe