### PR TITLE
Correction

### DIFF
--- a/pages/wiki/porting-status.hbs
+++ b/pages/wiki/porting-status.hbs
@@ -23,12 +23,16 @@ layout: documentation
 <p><strong>Possible ports not supported yet:</strong></p>
 <ul>
 <li>Casio Smart Outdoor Watch</li>
+<li>Diesel Full Guard (pinouts are on the inside)</li>
 <li>Elephone Ele Watch</li>
+<li>Emporio Armani Connected (pinouts are on the inside)</li>
+<li>Fossil Q Explorist (pinouts are on the inside)</li>
 <li>Guess Connect</li>
 <li>Huawei Watch</li>
 <li>Huawei Watch 2</li>
 <li>Hugo BOSS BOSS Touch</li>
 <li>LG Watch Urbane 2nd Edition</li>
+<li>Michael Kors Access Grayson (pinouts are on the inside)</li>
 <li>Misfit Vapor</li>
 <li>Montblanc Summit</li>
 <li>Moto 360 (1st generation)</li>
@@ -47,10 +51,7 @@ layout: documentation
 </ul>
 <p><strong>Impossible ports because of lack of pinouts:</strong></p>
 <ul>
-<li>Diesel Full Guard</li>
-<li>Emporio Armani Connected</li>
 <li>Fossil Q Control</li>
-<li>Fossil Q Explorist</li>
 <li>Fossil Q Founder</li>
 <li>Fossil Q Marshal</li>
 <li>Fossil Q Venture</li>
@@ -60,7 +61,6 @@ layout: documentation
 <li>LG Watch Style</li>
 <li>Louis Vuitton Tambour</li>
 <li>Michael Kors Access</li>
-<li>Michael Kors Access Grayson</li>
 <li>Michael Kors Access Mesdames</li>
 <li>Michael Kors Dylan</li>
 <li>Michael Kors Sofie</li>


### PR DESCRIPTION
All the changed watches are the same device called "bluegill" by Compal. When opened up they have the required pinouts.

![bluegill](https://user-images.githubusercontent.com/14153182/55472840-5f99f680-560d-11e9-9005-f2544c91af02.jpeg)
