### PR TITLE
Improve the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,18 @@
 
 Assemble and Grunt are used to build the site. To get started:
 
-1. Clone this repository
-2. In the root of the repo, run `npm install`
-3. Run the `grunt` command to build the site
+1. Make sure you have the following installed:
+   * [NodeJS](https://nodejs.org/en/download/)
+   * [Git](https://git-scm.com/downloads)
+2. Run:
+   ``` Bash
+   git clone https://github.com/AsteroidOS/asteroidos.org.git # Clone this repository
+   cd asteroidos.org # Go to the root of the repo
+   npm install # Install dependencies
+   npx grunt # Build the site (If your npm version is so old that it doesn't support npx, run `npm i -g grunt` followed by `grunt` instead)
+   ```
 
-If all worked properly, you should have your website ready in an '_asteroidos.org' folder
+If all worked properly, you should have your website ready in an `_asteroidos.org` folder
 
 ## License
 This website is a fork of lesscss.org


### PR DESCRIPTION
Since grunt will be installed to the node_modules, the right way to execute `grunt` would be `npx grunt`. 
Alternatively you could globally install `grunt`. However, that would be a a bit redundant.

So I just wanted to mention that the way to use grunt is `npx grunt`, unless you have an outdated npm version that doesn't come with npx yet. I also ended up some other minor things. (If you don't like them I can change it back.)