### PR TITLE
Replace '.' with 'source' to improve consistency

### DIFF
--- a/pages/wiki/creating-an-asteroid-app.hbs
+++ b/pages/wiki/creating-an-asteroid-app.hbs
@@ -12,7 +12,7 @@ layout: documentation
 cd asteroid/
 </code></pre>
 <p>Then, build the cross compilation toolchain with:</p>
-<pre><code>. ./prepare-build.sh dory
+<pre><code>source ./prepare-build.sh dory
 bitbake meta-toolchain-qt5
 </code></pre>
 <div class="page-header">


### PR DESCRIPTION
I think this was the only remaining occurrence of a '.' that could be replaced by 'source'.