### PR TITLE
Make code elements with lines longer than the width scrollable

### DIFF
--- a/styles/bootstrap/code.less
+++ b/styles/bootstrap/code.less
@@ -34,13 +34,14 @@ pre {
   background-color: @pre-bg;
   border: 1px solid @pre-border-color;
   border-radius: @border-radius-base;
+  overflow-x: auto; // Allow horizontal scrolling
 
   // Account for some code outputs that place code tags in pre tags
   code {
     padding: 0;
     font-size: inherit;
     color: inherit;
-    white-space: pre-wrap;
+    white-space: pre; // Don't wrap text
     background-color: transparent;
     border-radius: 0;
   }


### PR DESCRIPTION
Suggestion to have scrollbars in code tags with very long lines.

So ithat they would appear like this:

![image](https://user-images.githubusercontent.com/11368523/57730573-06f05b80-7699-11e9-962b-bac13108549e.png)

Instead of like this:

![image](https://user-images.githubusercontent.com/11368523/57730648-399a5400-7699-11e9-8bd0-25bb911a6b5f.png)

What do you think?