### PR TITLE
Fix logo margin on mobile

### DIFF
--- a/styles/components/main-nav.less
+++ b/styles/components/main-nav.less
@@ -15,7 +15,7 @@
 
   // increase specificity to override Bootstrap styles
   .container .navbar-brand {
-    margin: 12px 0 0;
+    margin: 12px 0 0 15px;
     @media (min-width: @grid-float-breakpoint) {
       margin: 27px 0 0;
     }


### PR DESCRIPTION
Logo in header had 0 left margin and it looked weird. I set this margin to 15px, because hamburger on right also has 15px and entire `.container` has 15px horizontal margin.

Screenshot before:
![before_localhost](https://user-images.githubusercontent.com/17083034/65963586-60e09a80-e45b-11e9-9ab1-f83499244ffe.png)

Screenshot after:
![after_localhost](https://user-images.githubusercontent.com/17083034/65963601-676f1200-e45b-11e9-88da-b7cdcead584a.png)

