### PR TITLE
Adds 'PineTime' to the impossible ports

### DIFF
--- a/pages/wiki/porting-status.hbs
+++ b/pages/wiki/porting-status.hbs
@@ -69,6 +69,10 @@ layout: documentation
 <li>Polar M600</li>
 <li>Skagen Falster</li>
 </ul>
+<p><strong>Impossible ports due to unmet hardware dependencies:</strong></p>
+<ul>
+<li>PineTime</li>
+</ul>
 <div class="page-header">
   <h1 id="tizensw">Tizen Smartwatches</h1>
 </div>


### PR DESCRIPTION
The 'PineTime' gets a lot of porting requests and does not meet the hardware requirements. This PR clarifies the state in our public documentation.