### PR TITLE
porting-status: Move Huawei GT/2 to impossible unmet hardware.

### DIFF
--- a/pages/wiki/porting-status.hbs
+++ b/pages/wiki/porting-status.hbs
@@ -56,8 +56,6 @@ layout: documentation
 <li>Fossil Q Venture</li>
 <li>Fossil Q Wander</li>
 <li>Gc Connect</li>
-<li>Huawei Watch GT</li>
-<li>Huawei Watch GT 2</li>
 <li>LG Watch Sport</li>
 <li>LG Watch Style</li>
 <li>Louis Vuitton Tambour</li>
@@ -71,6 +69,8 @@ layout: documentation
 </ul>
 <p><strong>Impossible ports due to unmet hardware dependencies:</strong></p>
 <ul>
+<li>Huawei Watch GT</li>
+<li>Huawei Watch GT 2</li>
 <li>PineTime</li>
 <li>Umidigi Uwatch GT</li>
 </ul>


### PR DESCRIPTION
As per https://github.com/AsteroidOS/asteroid/issues/121 we now know that the GT versions don't have the hardware to properly support Linux.