### PR TITLE
install: Wrap support row when screen is too narrow.

### DIFF
--- a/pages/install/anthias.hbs
+++ b/pages/install/anthias.hbs
@@ -4,23 +4,15 @@ deviceName: anthias
 layout: aw-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-good"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Compass<div class="support-col-bad"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+</div>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>

--- a/pages/install/bass.hbs
+++ b/pages/install/bass.hbs
@@ -5,29 +5,18 @@ section: install
 layout: aw-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-<th>WLAN</th>
-<th>Heart Rate</th>
-<th>Tilt-to-Wake</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-good"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Compass<div class="support-col-good"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+  <div class="support-col">WLAN<div class="support-col-good"></div></div>
+  <div class="support-col">Heart Rate<div class="support-col-good"></div></div>
+  <div class="support-col">Tilt-to-Wake<div class="support-col-good"></div></div>
+</div>
 
 <div class="callout callout-info">
     <h4>Hear rate sensor not working?</h4>

--- a/pages/install/dory.hbs
+++ b/pages/install/dory.hbs
@@ -4,22 +4,13 @@ deviceName: dory
 layout: aw-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-<th>Tilt-to-Wake</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-good"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Compass<div class="support-col-good"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+  <div class="support-col">Tilt-to-Wake<div class="support-col-bad"></div></div>
+</div>

--- a/pages/install/harmony.hbs
+++ b/pages/install/harmony.hbs
@@ -4,27 +4,17 @@ deviceName: harmony
 layout: mtk-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-<th>Camera</th>
-<th>Heart Rate</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-good"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Compass<div class="support-col-good"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+  <div class="support-col">Camera<div class="support-col-good"></div></div>
+  <div class="support-col">Heart Rate<div class="support-col-bad"></div></div>
+</div>
 
 <div class="callout callout-info">
     <h4>Harmony</h4>

--- a/pages/install/inharmony.hbs
+++ b/pages/install/inharmony.hbs
@@ -4,27 +4,17 @@ deviceName: inharmony
 layout: mtk-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-<th>Camera</th>
-<th>Heart Rate</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-good"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Compass<div class="support-col-good"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+  <div class="support-col">Camera<div class="support-col-good"></div></div>
+  <div class="support-col">Heart Rate<div class="support-col-bad"></div></div>
+</div>
 
 <div class="callout callout-info">
     <h4>Inharmony</h4>

--- a/pages/install/lenok.hbs
+++ b/pages/install/lenok.hbs
@@ -4,26 +4,15 @@ deviceName: lenok
 layout: aw-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-<th>WLAN</th>
-<th>Heart Rate</th>
-<th>Tilt-to-Wake</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-bad"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Compass<div class="support-col-bad"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+  <div class="support-col">WLAN<div class="support-col-good"></div></div>
+  <div class="support-col">Heart Rate<div class="support-col-good"></div></div>
+  <div class="support-col">Tilt-to-Wake<div class="support-col-good"></div></div>
+</div>

--- a/pages/install/mooneye.hbs
+++ b/pages/install/mooneye.hbs
@@ -4,20 +4,12 @@ deviceName: mooneye
 layout: mooneye-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-bad"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-bad"></div></div>
+  <div class="support-col">Compass<div class="support-col-good"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+</div>

--- a/pages/install/smelt.hbs
+++ b/pages/install/smelt.hbs
@@ -5,27 +5,17 @@ section: install
 layout: aw-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Haptics</th>
-<th>USB</th>
-<th>WLAN</th>
-<th>Heart Rate</th>
-<th>Tilt-to-Wake</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-bad"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+  <div class="support-col">WLAN<div class="support-col-good"></div></div>
+  <div class="support-col">Heart Rate<div class="support-col-good"></div></div>
+  <div class="support-col">Tilt-to-Wake<div class="support-col-good"></div></div>
+</div>
 
 <div class="callout callout-info">
     <h4>USB connection</h4>

--- a/pages/install/sparrow.hbs
+++ b/pages/install/sparrow.hbs
@@ -4,27 +4,17 @@ deviceName: sparrow
 layout: aw-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-<th>WLAN</th>
-<th>Tilt-to-Wake</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-bad"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Compass<div class="support-col-bad"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+  <div class="support-col">WLAN<div class="support-col-bad"></div></div>
+  <div class="support-col">Tilt-to-Wake<div class="support-col-good"></div></div>
+</div>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>

--- a/pages/install/sprat.hbs
+++ b/pages/install/sprat.hbs
@@ -4,6 +4,15 @@ deviceName: sprat
 layout: aw-install
 ---
 
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-good"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Compass<div class="support-col-bad"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+</div>
 <table width="100%"><thead><tr>
 <th>Display</th>
 <th>Touch</th>

--- a/pages/install/sturgeon.hbs
+++ b/pages/install/sturgeon.hbs
@@ -5,29 +5,18 @@ section: install
 layout: aw-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Speaker</th>
-<th>Bluetooth</th>
-<th>Haptics</th>
-<th>USB</th>
-<th>WLAN</th>
-<th>Heart Rate</th>
-<th>Tilt-to-Wake</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-good"></div></div>
+  <div class="support-col">Speaker<div class="support-col-good"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+  <div class="support-col">WLAN<div class="support-col-good"></div></div>
+  <div class="support-col">Heart Rate<div class="support-col-good"></div></div>
+  <div class="support-col">Tilt-to-Wake<div class="support-col-good"></div></div>
+</div>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>

--- a/pages/install/swift.hbs
+++ b/pages/install/swift.hbs
@@ -4,22 +4,14 @@ deviceName: swift
 layout: aw-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-<th>WLAN</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-</tr></tbody></table>
+
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-bad"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-bad"></div></div>
+  <div class="support-col">Compass<div class="support-col-bad"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+  <div class="support-col">WLAN<div class="support-col-good"></div></div>
+</div>

--- a/pages/install/tetra.hbs
+++ b/pages/install/tetra.hbs
@@ -4,25 +4,16 @@ deviceName: tetra
 layout: aw-install-simg
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-<th>WLAN</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-bad"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Compass<div class="support-col-bad"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+  <div class="support-col">WLAN<div class="support-col-good"></div></div>
+</div>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>

--- a/pages/install/wren.hbs
+++ b/pages/install/wren.hbs
@@ -4,25 +4,16 @@ deviceName: wren
 layout: aw-install
 ---
 
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-<th>WLAN</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-</tr></tbody></table>
+<div class="support-row">
+  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Touch<div class="support-col-good"></div></div>
+  <div class="support-col">Microphone<div class="support-col-bad"></div></div>
+  <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
+  <div class="support-col">Compass<div class="support-col-bad"></div></div>
+  <div class="support-col">Haptics<div class="support-col-good"></div></div>
+  <div class="support-col">USB<div class="support-col-good"></div></div>
+  <div class="support-col">WLAN<div class="support-col-bad"></div></div>
+</div>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>

--- a/styles/components/install-support-table.less
+++ b/styles/components/install-support-table.less
@@ -1,0 +1,38 @@
+//
+// Install Support Tables
+// --------------------------------------------------
+
+.support-row {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.support-col {
+  width: auto;
+  max-width: 100%;
+  // Grow colums to fill entire width.
+  flex: 1 0 auto;
+  // Make font bold.
+  font-weight: 700;
+  // Add minimal gap between columns.
+  margin: 1px;
+  padding: 0 !important;
+}
+
+.support-col-good {
+  height: 25px;
+  background-color: #5ab948;
+}
+
+.support-col-unknown {
+  height: 25px;
+  background-color: #ffa31a;
+}
+
+.support-col-bad {
+  height: 25px;
+  background-color: #b94a48;
+}

--- a/styles/index.less
+++ b/styles/index.less
@@ -31,6 +31,7 @@
 @import "footer.less";
 @import "components/tables.less";
 @import "docs-content.less";
+@import "install-support-table.less";
 @import "install-box.less";
 @import "install-preparation-box.less";
 @import "community-box.less";


### PR DESCRIPTION
This PR changes the support table such that it wraps to the next row when it overflows.

Here is a comparison of what it looked like and what it looks like after the PR. Top one is the new implementation the bottom one is the old table.
![asteroidosorg_support_wrap_prev_cur](https://user-images.githubusercontent.com/7857908/98005637-92136300-1df1-11eb-87cf-64dd230e91ec.png)

Here are two images of what it looks like when the screen is too narrow:
![asteroidosorg_support_wrap_demo](https://user-images.githubusercontent.com/7857908/98005605-87f16480-1df1-11eb-85f7-1e6ffaa90374.png)

![asteroidosorg_support_wrap_demo_2](https://user-images.githubusercontent.com/7857908/98005618-8b84eb80-1df1-11eb-8d90-f74889a4a1c4.png)


Also I added a another color to indicate that the status of something is unknown:
![asteroidosorg_support_wrap_color_palette](https://user-images.githubusercontent.com/7857908/98005630-8e7fdc00-1df1-11eb-9f96-a33e0223959b.png)