### PR TITLE
enables markdown in the Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,12 +68,12 @@ module.exports = function(grunt) {
           cwd: '<%= site.pages %>/',
           dest: '<%= site.dest %>/',
           expand: true,
-          src: ['**/*.hbs', '!main/**/*.hbs']
+          src: ['**/*.{hbs,md}', '!main/**/*.{hbs,md}']
         }, {
           cwd: '<%= site.pages %>/main/',
           dest: '<%= site.dest %>/',
           expand: true,
-          src: '**/*.hbs'
+          src: '**/*.{hbs,md}'
         }]
       }
     },


### PR DESCRIPTION
I was checking #89 on a clean copy of the master branch to check for any breaking changes and noticed that it doesn't generate HTML files at all.

This commit adds the markdown file extension (`.md`) to the source file regex in the Gruntfile.