### PR TITLE
User used for app development has to be ceres

### DIFF
--- a/pages/wiki/creating-an-asteroid-app.md
+++ b/pages/wiki/creating-an-asteroid-app.md
@@ -60,7 +60,7 @@ Now that you are in QtCreator go to ‘_Tools-&gt;Options-&gt;Devices_‘
 - Add a new Generic Linux Device.
 - Name it "AsteroidOS Watch".
 - Choose 192.168.2.15 as IP address.
-- Use root as user.
+- Use ceres as user.
 - Choose Password authentication and leave the password field empty.
 
 


### PR DESCRIPTION
Thank you @MagneFire for your help. Pretty sure i would have spent many more hours if i did not had your help.

The user for running selfmade qt applications has to  be ceres. Root will not work.