### PR TITLE
Update Yocto docs link

### DIFF
--- a/pages/wiki/openembedded.md
+++ b/pages/wiki/openembedded.md
@@ -8,5 +8,5 @@ layout: documentation
 <p>Layers are git repositories containing a bunch of related recipes, example of layers include board support packages like <a href="https://github.com/AsteroidOS/meta-dory-hybris">meta-dory-hybris</a> or meta-rockchip which describe a way to support a new machine, but also UI layers like meta-xfce or meta-gnome which describe the building process of graphic components.</p>
 <p>A recipe describe how to fetch, patch, configure, compile, install, package (in .rpm, .deb or .ipk) and test a piece of software. Bitbake handles all those operations and dependencies between them and between recipes. In the end it can generate images or SDK for multiple targets.</p>
 <p>Contributing to the AsteroidOS’s OE architecture mostly consists in maintaining the <a href="https://github.com/AsteroidOS/meta-asteroid">meta-asteroid</a> and meta-*-hybris repositories which contain the recipes related to Asteroid and the watches BSPs.</p>
-<p>In depth info can be found in <a href="http://www.yoctoproject.org/docs/2.0/mega-manual/mega-manual.html">the Mega-Manual</a>.</p>
+<p>In depth info can be found in <a href="https://docs.yoctoproject.org/index.html">the Yocto Project's manual</a>.</p>
 <img src="{{assets}}/img/openembedded.png" style="width:100%"/>


### PR DESCRIPTION
Previously pointing to 2.0; we're using 3.2 (gatesgarth) currently. This link points to the latest version of the docs. Also, I pointed it to an index rather than to the Mega-Manual page; the mega-manual definitely has its uses but it's a bit cumbersome to read. It's linked from the index, so still fairly easy to find.