### PR TITLE
add zstd and liblz4-tool to dependencies

### DIFF
--- a/pages/wiki/building-asteroidos.md
+++ b/pages/wiki/building-asteroidos.md
@@ -48,7 +48,7 @@ Install the prerequisites:
 
 
 ```
-apt-get install git build-essential cpio diffstat gawk chrpath texinfo python2 python3 wget shared-mime-info
+apt-get install git build-essential cpio diffstat gawk chrpath texinfo python2 python3 wget shared-mime-info zstd liblz4-tool
 ```
 
 This repository basically only contains a shell script that populates *src/* with OpenEmbedded and the appropriate Asteroid layers. Then, it setups the environment for a bitbake build. The following command will setup a build for *dory* (the LG G Watch) but you can also build an image for other watches by using the corresponding codename. (Codenames can be found on the <a href="{{rel 'install'}}">Install page</a>.)


### PR DESCRIPTION
This should fix the following error:
```
ERROR: The following required tools (as specified by HOSTTOOLS) appear to be unavailable in PATH, please install them in order to proceed:
  lz4c pzstd zstd 
 ```