### PR TITLE
Add Sensor Support And Add Star To Skipjack

### DIFF
--- a/pages/install/skipjack.md
+++ b/pages/install/skipjack.md
@@ -12,9 +12,8 @@ layout: aw-install
   <div class="support-col">GPS<div class="support-col-bad"></div></div>
   <div class="support-col">NFC<div class="support-col-bad"></div></div>
   <div class="support-col">WLAN<div class="support-col-bad"></div></div>
-  <div class="support-col">Heart Rate<div class="support-col-bad"></div></div>
-  <div class="support-col">Tilt-to-Wake<div class="support-col-bad"></div></div>
-  <div class="support-col">Compass<div class="support-col-bad"></div></div>
+  <div class="support-col">Heart Rate<div class="support-col-good"></div></div>
+  <div class="support-col">Tilt-to-Wake<div class="support-col-good"></div></div>
   <div class="support-col">Haptics<div class="support-col-good"></div></div>
   <div class="support-col">USB<div class="support-col-good"></div></div>
 </div>

--- a/pages/main/install.md
+++ b/pages/main/install.md
@@ -62,6 +62,11 @@ If you have questions regarding the installation process, please check out the *
   <b>Huawei Watch 2</b><br>(sawfish/sawshark)<br>
   <i>Support: <span class="star-good"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
 </div></a>
+<a href="{{rel '/install/skipjack'}}"><div class="install-box">
+  <img src="{{assets}}/img/skipjack.png" width="100%"><br>
+  <b>TicWatch C2+</b><br>(skipjack)<br>
+  <i>Support: <span class="star-good"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
+</div></a>
 <a href="{{rel '/install/firefish'}}"><div class="install-box">
   <img src="{{assets}}/img/firefish.png" width="100%"><br>
   <b>Fossil Gen 4</b><br>(firefish)<br>
@@ -71,11 +76,6 @@ If you have questions regarding the installation process, please check out the *
   <img src="{{assets}}/img/mooneye.png" width="100%"><br>
   <b>Ticwatch E & S</b><br>(mooneye)<br>
   <i>Support: <span class="star-good"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
-</div></a>
-<a href="{{rel '/install/skipjack'}}"><div class="install-box">
-  <img src="{{assets}}/img/skipjack.png" width="100%"><br>
-  <b>TicWatch C2+</b><br>(skipjack)<br>
- <i>Support: <span class="star-good"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span>
 </div></a>
 <a href="{{rel '/install/ray'}}"><div class="install-box">
   <img src="{{assets}}/img/ray.png" width="100%"><br>


### PR DESCRIPTION
To be merged after https://github.com/AsteroidOS/meta-skipjack-hybris/pull/11 is merged, this PR adds Sensor Support where it counts, both in the Heart Rate Monitor and Tilt-To-Wake sensor, although Skipjack does not have a compass (Sad).

Also seems fitting based on the amount of supported hardware devices to bump Skipjack from two stars to three stars.