### PR TITLE
Explain that ADB is not the only option to access the bootloader

### DIFF
--- a/templates/layouts/aw-install-simg.hbs
+++ b/templates/layouts/aw-install-simg.hbs
@@ -45,7 +45,9 @@
 
       <h1>Instructions</h1>
       <h3>1. Unlock your bootloader</h3>
-      Installing AsteroidOS requires an unlocked bootloader and entering the bootloader requires ADB in Wear OS.
+      Installing AsteroidOS requires an unlocked bootloader. Accessing the bootloader can be achieved via ADB in Wear OS, as described in steps 1.1 to 1.4 below.
+      <br>You can skip these steps if you are familiar with the manual method to access the bootloader. This method is different for most watches, but usually involves an input combination during the first few seconds of the boot process.
+      <br>
       <br>Enable ADB on your watch with the following steps:
         <ol>
           <img src="{{assets}}/img/install-1.jpg" class="install-centered-img"/>

--- a/templates/layouts/aw-install.hbs
+++ b/templates/layouts/aw-install.hbs
@@ -44,7 +44,9 @@
 
       <h1>Instructions</h1>
       <h3>1. Unlock your bootloader</h3>
-      Installing AsteroidOS requires an unlocked bootloader and entering the bootloader requires ADB in Wear OS.
+      Installing AsteroidOS requires an unlocked bootloader. Accessing the bootloader can be achieved via ADB in Wear OS, as described in steps 1.1 to 1.4 below.
+      <br>You can skip these steps if you are familiar with the manual method to access the bootloader. This method is different for most watches, but usually involves an input combination during the first few seconds of the boot process.
+      <br>
       <br>Enable ADB on your watch with the following steps:
         <ol>
           <img src="{{assets}}/img/install-1.jpg" class="install-centered-img"/>

--- a/templates/layouts/mooneye-install.hbs
+++ b/templates/layouts/mooneye-install.hbs
@@ -44,7 +44,9 @@
 
       <h1>Instructions</h1>
       <h3>1. Unlock your bootloader</h3>
-      Installing AsteroidOS requires an unlocked bootloader and entering the bootloader requires ADB in Wear OS.
+      Installing AsteroidOS requires an unlocked bootloader. Accessing the bootloader can be achieved via ADB in Wear OS, as described in steps 1.1 to 1.4 below.
+      <br>You can skip these steps if you are familiar with the manual method to access the bootloader. This might need some practice and timing. Hold down the power until the watch reboots. When the MOBVOI logo appears, quickly slide on the screen from the upper left corner to the lower right corner.
+      <br>
       <br>Enable ADB on your watch with the following steps:
         <ol>
           <img src="{{assets}}/img/install-1.jpg" class="install-centered-img"/>


### PR DESCRIPTION
As made aware by user silentnoodlemaster on matrix by trying to make a degooglified phone work with the installing WearOS only to unlock the bootloader.
It would be advised to make users aware of the manual methods to access the bootloader.