### PR TITLE
Move IP connectivity logic to a separate page

### DIFF
--- a/pages/wiki/ip-connection.md
+++ b/pages/wiki/ip-connection.md
@@ -26,7 +26,7 @@ connmanctl&gt; connect wifi_CODE-FOR-YOUR-SSID
 connmanctl&gt; quit
 </code></pre>
 
-Verfify that you got an ip adress asigned with <code># ip a show dev wlan0</code>.
+Verfify that you got an ip address asigned with <code># ip a show dev wlan0</code>.
 
 Some more <a href="https://wiki.archlinux.org/index.php/ConnMan#Connecting_to_a_protected_access_point">details</a> on ArchWiki
 

--- a/pages/wiki/ip-connection.md
+++ b/pages/wiki/ip-connection.md
@@ -1,0 +1,49 @@
+---
+title: IP Connection
+layout: documentation
+---
+
+Configuring an IP connection on your watch has to be done manually until a GUI settings option is available.
+On watches with supported WLan, you can enable wifi and configure the connection using <code>connmanctl</code> like described below.
+Forwarding IP requests to a connected PC via USB is another option, explained in the second paragraph.
+
+By default, there is no <code>root</code> or <code>ceres</code> password, and no firewall rules. A password can be set using the <code>passwd</code> command.
+
+
+
+# IP over WLan
+
+*****
+
+Connect to your watch using <code>ssh root@192.168.2.15</code> or <code>adb shell</code>.
+
+<pre><code># connmanctl
+connmanctl&gt; enable wifi
+connmanctl&gt; scan wifi
+connmanctl&gt; services
+connmanctl&gt; agent on
+connmanctl&gt; connect wifi_CODE-FOR-YOUR-SSID
+connmanctl&gt; quit
+</code></pre>
+
+Verfify that you got an ip adress asigned with <code># ip a show dev wlan0</code>.
+
+Some more <a href="https://wiki.archlinux.org/index.php/ConnMan#Connecting_to_a_protected_access_point">details</a> on ArchWiki
+
+
+
+# IP over USB
+
+*****
+
+
+Configure a NAT **on your computer** (Note: Replace eth0 with the name of the interface that connects your computer to the Internet) with:
+
+    echo 1 > /proc/sys/net/ipv4/ip_forward
+    iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+
+Configure a default gateway and DNS **on the watch** with the following commands ran via [SSH](https://asteroidos.org/wiki/ssh/):
+
+    route add default gw 192.168.2.1
+    echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+

--- a/pages/wiki/ip-connection.md
+++ b/pages/wiki/ip-connection.md
@@ -4,14 +4,14 @@ layout: documentation
 ---
 
 Configuring an IP connection on your watch has to be done manually until a GUI settings option is available.
-On watches with supported WLan, you can enable wifi and configure the connection using <code>connmanctl</code> like described below.
+On watches that support WLAN, you can enable Wi-Fi and configure the connection using <code>connmanctl</code> like described below.
 Forwarding IP requests to a connected PC via USB is another option, explained in the second paragraph.
 
 By default, there is no <code>root</code> or <code>ceres</code> password, and no firewall rules. A password can be set using the <code>passwd</code> command.
 
 
 
-# IP over WLan
+# IP over WLAN
 
 *****
 

--- a/pages/wiki/ssh.md
+++ b/pages/wiki/ssh.md
@@ -7,7 +7,7 @@ layout: documentation
 <div class="page-header">
   <h1 id="sshoverusb">SSH over USB</h1>
 </div>
-<p>By default, USB Moded set up udhcpd so that your watch gets the 192.168.2.15 IP address on its rndis interface. You can then connect to your watch from your computer with the following command:</p>
+<p>USB Moded already set up udhcpd so that your watch gets the 192.168.2.15 IP address on its rndis interface. You can then connect to your watch from your computer with the following command:</p>
 <pre><code>ssh ceres@192.168.2.15
 </code></pre>
 <p>If your computer does not automatically get an IP address for its rndis interface, you might need to run this first:</p>
@@ -16,20 +16,6 @@ layout: documentation
 <div class="page-header">
   <h1 id="sshoverwifi">SSH over Wi-Fi</h1>
 </div>
-<p>Dropbear is already running on the watch so we just need an IP address configured to connect.</p>
-<p>Ensure wireless drivers are enabled for the watch.</p>
-<p>Build your <code>asteroid-image</code> with iproute2 and wpa-supplicant. In <code>meta-{watch}-hybris/conf/machine/{watch}.conf</code> add <code>iproute2</code> and <code>wpa-supplicant</code> to <code>IMAGE_INSTALL</code>:</p>
-<pre><code>IMAGE_INSTALL += "android-tools android-system msm-fb-refresher brcm-patchram-plus iproute2 wpa-supplicant connman-client"</code></pre>
-<p>Once your image is installed on the watch, open up an <code>adb shell</code> or <code>ssh root@192.168.2.15</code>:</p>
-<pre><code># connmanctl
-connmanctl&gt; enable wifi
-connmanctl&gt; scan wifi
-connmanctl&gt; services
-connmanctl&gt; agent on
-connmanctl&gt; connect wifi_<code for your ssid>
-connmanctl&gt; quit
-# ip a show dev wlan0
-</code></pre>
-<p>some more <a href="https://wiki.archlinux.org/index.php/ConnMan#Connecting_to_a_protected_access_point">details</a> on ArchWiki</p>
-<p>The watch should automatically get an IPv6 address from your network or you can set a static IPv4. You can disconnect from adb and connect via SSH.</p>
-<p>By default, there is no <code>root</code> or <code>ceres</code> password, and no firewall rules.</p>
+<p>Dropbear is already running on the watch so we just need to configured an IP address to connect.</p>
+<p>The <a href="https://asteroidos.org/wiki/ip-connection">IP Connection page</a> describes how to set up wifi.</p>
+<p>Once the setup is done, you can look for the IP adress your Router assigned via DHCP, with <code># ip a show dev wlan0</code>.</p>

--- a/pages/wiki/ssh.md
+++ b/pages/wiki/ssh.md
@@ -16,6 +16,6 @@ layout: documentation
 <div class="page-header">
   <h1 id="sshoverwifi">SSH over Wi-Fi</h1>
 </div>
-<p>Dropbear is already running on the watch so we just need to configured an IP address to connect.</p>
-<p>The <a href="https://asteroidos.org/wiki/ip-connection">IP Connection page</a> describes how to set up wifi.</p>
-<p>Once the setup is done, you can look for the IP adress your Router assigned via DHCP, with <code># ip a show dev wlan0</code>.</p>
+<p>Dropbear is already running on the watch so we just need to configure an IP address to connect to.</p>
+<p>The <a href="https://asteroidos.org/wiki/ip-connection">IP Connection page</a> describes how to set up Wi-Fi.</p>
+<p>Once the setup is done, you can look for the IP address your Router assigned via DHCP, with <code># ip a show dev wlan0</code>.</p>

--- a/pages/wiki/update-asteroidos.md
+++ b/pages/wiki/update-asteroidos.md
@@ -3,7 +3,7 @@ title: Update AsteroidOS
 layout: documentation
 ---
 
-As currently no AsteroidOS watches have direct access to the Internet, no OTA upgrades are offered. This page documents upgrading AsteroidOS.
+As currently no AsteroidOS watch has access to the internet by stock means, no OTA upgrades are offered. This page documents upgrading AsteroidOS.
 
 
 # Reflash AsteroidOS
@@ -20,11 +20,45 @@ If your watch is in Developer Mode, run the following command on your computer: 
 
 If your watch is in ADB Mode, run the following command on your computer: `adb shell reboot -f bootloader`.
 
+
+# Upgrade using OPKG
+
+*****
+
+If you don't want to lose your personal data, and prefer upgrading Asteroid without reflashing it, you have two options to establish an interent connection from the watch.
+
+In case your watch supports Wifi, connect it to your local WLan using <code>connmanctl</code> as described in the next section. Alternatively you can share your internet connection from a PC to the watch via USB. 
+
+Once your watch can connect to the internet, you can use AsteroidOS' package manager: opkg
+
+The standard commands to upgrade are:
+
+    opkg update
+    opkg upgrade
+
+
+# OPKG over Wifi
+
+*****
+
+Connect to your watch using <code>ssh root@192.168.2.15</code> or <code>adb shell</code>.
+
+<pre><code># connmanctl
+connmanctl&gt; enable wifi
+connmanctl&gt; scan wifi
+connmanctl&gt; services
+connmanctl&gt; agent on
+connmanctl&gt; connect wifi_YOUR-SSID
+connmanctl&gt; quit
+</code></pre>
+
+Verfify that you got an ip adress asigned with <code># ip a show dev wlan0</code> and upgrade as described above.
+
+
 # OPKG over USB
 
 *****
 
-If you don't want to lose your personal data, and prefer upgrading Asteroid without reflashing it, you can share your Internet connection from a PC to the watch and use AsteroidOS' package manager: opkg
 
 Configure a NAT **on your computer** (Note: Replace eth0 with the name of the interface that connects your computer to the Internet) with:
 
@@ -36,7 +70,3 @@ Configure a default gateway and DNS **on the watch** with the following commands
     route add default gw 192.168.2.1
     echo "nameserver 8.8.8.8" >> /etc/resolv.conf
 
-Then upgrade your AsteroidOS with opkg, using the standard commands:
-
-    opkg update
-    opkg upgrade

--- a/pages/wiki/update-asteroidos.md
+++ b/pages/wiki/update-asteroidos.md
@@ -11,7 +11,7 @@ As currently no AsteroidOS watch has access to the internet by stock means, no G
 
 *****
 
-If you don't want to lose your personal data, and prefer upgrading Asteroid without reflashing it, you have two options to establish an internet connection from the watch.
+If you don't want to loose your personal data, and prefer upgrading Asteroid without reflashing it, you have two options to establish an internet connection from the watch.
 
 In case your watch supports WLAN, connect it to your local Wi-Fi network using <code>connmanctl</code> as described on the [IP Connection page](https://asteroidos.org/wiki/ip-connection/). Alternatively you can share your internet connection from a PC to the watch via USB. 
 

--- a/pages/wiki/update-asteroidos.md
+++ b/pages/wiki/update-asteroidos.md
@@ -13,7 +13,7 @@ As currently no AsteroidOS watch has access to the internet by stock means, no G
 
 If you don't want to lose your personal data, and prefer upgrading Asteroid without reflashing it, you have two options to establish an internet connection from the watch.
 
-In case your watch supports Wifi, connect it to your local WLan using <code>connmanctl</code> as described on the [IP Connection page](https://asteroidos.org/wiki/ip-connection/). Alternatively you can share your internet connection from a PC to the watch via USB. 
+In case your watch supports WLAN, connect it to your local Wi-Fi network using <code>connmanctl</code> as described on the [IP Connection page](https://asteroidos.org/wiki/ip-connection/). Alternatively you can share your internet connection from a PC to the watch via USB. 
 
 Once your watch can connect to the internet, you can use AsteroidOS' package manager: `opkg`
 
@@ -30,7 +30,7 @@ The standard commands to upgrade are:
 
 When no IP connection can be established on your watch, the easiest way to upgrade is to reflash the entire OS following the usual [installation instructions](https://asteroidos.org/install/).
 
-You will first have to reboot into fastboot, which is slightly different under AsteroidOS than it is under Android Wear.
+You will first have to reboot into fastboot, which is slightly different under AsteroidOS than it is under WearOS.
 
 First, go to Settings -> USB and make sure your device is in either `Developer Mode` or `ADB Mode` and connect it to your computer.
 

--- a/pages/wiki/update-asteroidos.md
+++ b/pages/wiki/update-asteroidos.md
@@ -3,14 +3,32 @@ title: Update AsteroidOS
 layout: documentation
 ---
 
-As currently no AsteroidOS watch has access to the internet by stock means, no OTA upgrades are offered. This page documents upgrading AsteroidOS.
+As currently no AsteroidOS watch has access to the internet by stock means, no GUI for OTA upgrades is offered. This page documents upgrading AsteroidOS.
+
+
+
+# Upgrade using OPKG
+
+*****
+
+If you don't want to lose your personal data, and prefer upgrading Asteroid without reflashing it, you have two options to establish an internet connection from the watch.
+
+In case your watch supports Wifi, connect it to your local WLan using <code>connmanctl</code> as described on the [IP Connection page](https://asteroidos.org/wiki/ip-connection/). Alternatively you can share your internet connection from a PC to the watch via USB. 
+
+Once your watch can connect to the internet, you can use AsteroidOS' package manager: `opkg`
+
+The standard commands to upgrade are:
+
+    opkg update
+    opkg upgrade
+
 
 
 # Reflash AsteroidOS
 
 *****
 
-The easiest way is to reflash the entire OS following the usual [installation instructions](https://asteroidos.org/install/).
+When no IP connection can be established on your watch, the easiest way to upgrade is to reflash the entire OS following the usual [installation instructions](https://asteroidos.org/install/).
 
 You will first have to reboot into fastboot, which is slightly different under AsteroidOS than it is under Android Wear.
 
@@ -20,53 +38,4 @@ If your watch is in Developer Mode, run the following command on your computer: 
 
 If your watch is in ADB Mode, run the following command on your computer: `adb shell reboot -f bootloader`.
 
-
-# Upgrade using OPKG
-
-*****
-
-If you don't want to lose your personal data, and prefer upgrading Asteroid without reflashing it, you have two options to establish an interent connection from the watch.
-
-In case your watch supports Wifi, connect it to your local WLan using <code>connmanctl</code> as described in the next section. Alternatively you can share your internet connection from a PC to the watch via USB. 
-
-Once your watch can connect to the internet, you can use AsteroidOS' package manager: opkg
-
-The standard commands to upgrade are:
-
-    opkg update
-    opkg upgrade
-
-
-# OPKG over Wifi
-
-*****
-
-Connect to your watch using <code>ssh root@192.168.2.15</code> or <code>adb shell</code>.
-
-<pre><code># connmanctl
-connmanctl&gt; enable wifi
-connmanctl&gt; scan wifi
-connmanctl&gt; services
-connmanctl&gt; agent on
-connmanctl&gt; connect wifi_YOUR-SSID
-connmanctl&gt; quit
-</code></pre>
-
-Verfify that you got an ip adress asigned with <code># ip a show dev wlan0</code> and upgrade as described above.
-
-
-# OPKG over USB
-
-*****
-
-
-Configure a NAT **on your computer** (Note: Replace eth0 with the name of the interface that connects your computer to the Internet) with:
-
-    echo 1 > /proc/sys/net/ipv4/ip_forward
-    iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
-
-Configure a default gateway and DNS **on the watch** with the following commands ran via [SSH](https://asteroidos.org/wiki/ssh/):
-
-    route add default gw 192.168.2.1
-    echo "nameserver 8.8.8.8" >> /etc/resolv.conf
-
+In case your watch does not successfully boot, try the manual methods to reach the fastboot (bootloader) menu described in the last section of the [useful commands page](https://asteroidos.org/wiki/useful-commands/).


### PR DESCRIPTION
As hinted by user coolguest25 on matrix. 
Adding wifi instructions since most watches with wifi capability have it supported in the meanwhile.