### PR TITLE
More installation details & installation fix for carp/smelt on Windows

### DIFF
--- a/pages/install/catfish.md
+++ b/pages/install/catfish.md
@@ -1,6 +1,7 @@
 ---
 title: Ticwatch Pro
 deviceName: catfish
+repo: catfish/catfish_ext/catshark
 layout: aw-install
 ---
 

--- a/pages/install/firefish.md
+++ b/pages/install/firefish.md
@@ -1,7 +1,7 @@
 ---
 title: Fossil Gen 4
 deviceName: firefish
-repo: ray
+repo: ray/firefish
 section: install
 layout: aw-install
 ---

--- a/pages/install/ray.md
+++ b/pages/install/ray.md
@@ -1,6 +1,7 @@
 ---
 title: Skagen Falster 2
 deviceName: ray
+repo: ray/firefish
 section: install
 layout: aw-install
 ---

--- a/pages/install/smelt.md
+++ b/pages/install/smelt.md
@@ -2,6 +2,7 @@
 title: Moto 360 2015
 deviceName: smelt
 repo: carp/smelt
+windowsDrivers: https://motorola-global-portal.custhelp.com/euf/assets/downloads/Motorola_Mobile_Drivers_64bit.msi
 section: install
 layout: aw-install
 ---

--- a/pages/install/smelt.md
+++ b/pages/install/smelt.md
@@ -1,6 +1,7 @@
 ---
 title: Moto 360 2015
 deviceName: smelt
+repo: carp/smelt
 section: install
 layout: aw-install
 ---

--- a/pages/main/install.md
+++ b/pages/main/install.md
@@ -44,7 +44,7 @@ If you have questions regarding the installation process, please check out the *
 </div></a>
 <a href="{{rel '/install/catfish'}}"><div class="install-box">
   <img src="{{assets}}/img/catfish.png" width="100%"><br>
-  <b>TicWatch Pro 2018/2020</b><br>(catfish/catfish_ext)<br>
+  <b>TicWatch Pro 2018/2020</b><br>(catfish/catfish_ext/catshark)<br>
   <i>Support: <span class="star-good"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
 </div></a>
 <a href="{{rel '/install/dory'}}"><div class="install-box">

--- a/templates/layouts/aw-install.hbs
+++ b/templates/layouts/aw-install.hbs
@@ -29,9 +29,9 @@
         <br><br>
         <pre><code class="bash">sudo apt install android-tools-adb android-tools-fastboot</code></pre>
         <br>
-        <b>On Windows systems</b> install this ADB driver <a href="https://adb.clockworkmod.com/">from clockworkmod</a>
+        <b>On Windows systems</b> install this ADB driver
         <br><br>
-        <a class="btn btn-primary" href="http://download.clockworkmod.com/test/UniversalAdbDriverSetup.msi" role="button">UniversalAdbDriverSetup.msi</a>
+        <a class="btn btn-primary" href="{{#if windowsDrivers}}{{windowsDrivers}}{{else}}http://download.clockworkmod.com/test/UniversalAdbDriverSetup.msi{{/if}}" role="button">{{#if windowsDrivers}}{{replace windowsDrivers ".*\/" "" ""}}{{else}}UniversalAdbDriverSetup.msi{{/if}}</a>
         <br><br>
         Download this zip file containing ADB & Fastboot from Android SDK
         <br><br>

--- a/templates/layouts/aw-install.hbs
+++ b/templates/layouts/aw-install.hbs
@@ -14,7 +14,7 @@
       <h1>Hardware Support</h1>
       <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}. The following table should summarize the current support of this watch:</p>
       {{> body }}
-      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label {{#if repo}}{{repo}}{{else}}{{deviceName}}{{/if}} for issues specific to your watch.</p>
+      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label <code>{{#if repo}}{{repo}}{{else}}{{deviceName}}{{/if}}</code> for issues specific to your watch.</p>
       <h1>Preparation</h1>
       <div class="install-preparation-box">
         <h3>Download AsteroidOS nightly builds</h3>


### PR DESCRIPTION
Adds more details to the individual installation pages as a follow-up to https://github.com/AsteroidOS/asteroidos.org/pull/152.

Additionally, this uses a custom template for `carp/smelt` to refer to different drivers for Windows as the universal ones don't seem to work. This was reported by @docgalaxyblock (Thanks!)