### PR TITLE
sturgeon: Mention all GT variants and link to the porting status page.

### DIFF
--- a/pages/install/sturgeon.md
+++ b/pages/install/sturgeon.md
@@ -20,5 +20,5 @@ layout: aw-install
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>
-    <p>The Huawei Watch GT and GT2 are not supported!</p>
+    <p>Huawei Watch GT variants are not supported! See the list on the <a href="{{rel 'wiki/porting-status'}}">porting status</a> page to find out if your model is supported.</p>
 </div>


### PR DESCRIPTION
It seems that there are GT3 and GT runner variants now, they are not compatible with sturgeon.
