### PR TITLE
Correct watch branding errors.

### DIFF
--- a/pages/install/bass.md
+++ b/pages/install/bass.md
@@ -1,5 +1,5 @@
 ---
-title: LG G Watch Urbane
+title: LG Watch Urbane
 deviceName: bass
 section: install
 layout: aw-install

--- a/pages/install/catfish.md
+++ b/pages/install/catfish.md
@@ -1,5 +1,5 @@
 ---
-title: Ticwatch Pro
+title: TicWatch Pro
 deviceName: catfish
 repo: catfish/catfish_ext/catshark
 layout: aw-install

--- a/pages/install/mooneye.md
+++ b/pages/install/mooneye.md
@@ -1,5 +1,5 @@
 ---
-title: Ticwatch E & S
+title: TicWatch E & S
 deviceName: mooneye
 layout: mooneye-install
 ---

--- a/pages/install/skipjack.md
+++ b/pages/install/skipjack.md
@@ -1,5 +1,5 @@
 ---
-title: Ticwatch C2+
+title: TicWatch C2+
 deviceName: skipjack
 layout: aw-install
 ---

--- a/pages/main/install.md
+++ b/pages/main/install.md
@@ -94,7 +94,7 @@ If you have questions regarding the installation process, please check out the *
 </div></a>
 <a href="{{rel '/install/mooneye'}}"><div class="install-box">
   <img src="{{assets}}/img/mooneye.png" width="100%"><br>
-  <b>Ticwatch E & S</b><br>(mooneye)<br>
+  <b>TicWatch E & S</b><br>(mooneye)<br>
   <i>Support: <span class="star-good"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
 </div></a>
 <a href="{{rel '/install/swift'}}"><div class="install-box">

--- a/pages/main/install.md
+++ b/pages/main/install.md
@@ -9,7 +9,7 @@ If you have questions regarding the installation process, please check out the *
 
 <a href="{{rel 'install/bass'}}"><div class="install-box">
   <img src="{{assets}}/img/bass.png" width="100%"><br>
-  <b>LG G Watch Urbane</b><br>(bass)<br>
+  <b>LG Watch Urbane</b><br>(bass)<br>
   <i>Support: <span class="star-good"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"><i class="icon ion-md-star"><i class="icon ion-md-star"></i></span></i>
 </div></a>
 <a href="{{rel '/install/sturgeon'}}"><div class="install-box">

--- a/pages/wiki/porting-status.md
+++ b/pages/wiki/porting-status.md
@@ -19,8 +19,8 @@ The WearOS smartwatches are the most widespread and easy to support. The source 
 - Huawei Watch 2 *(maintained by MagneFire, flocke, fosspill, FlorentBrianFoxcorner, jrt and the community)*
 - LG G Watch *(maintained by kido)*
 - LG G Watch R *(maintained by atx)*
-- LG G Watch Urbane *(maintained by TheAppleMan & kido)*
-- LG G Watch W7 *(maintained by dodoradio & MagneFire)*
+- LG Watch Urbane *(maintained by TheAppleMan & kido)*
+- LG Watch W7 *(maintained by dodoradio & MagneFire)*
 - Moto 360 (2nd generation) *(maintained by MagneFire)*
 - Skagen Falster 2 *(maintained by MagneFire)*
 - OPPO Watch *(maintained by MagneFire & wannaphong)*

--- a/pages/wiki/porting-status.md
+++ b/pages/wiki/porting-status.md
@@ -26,9 +26,9 @@ The WearOS smartwatches are the most widespread and easy to support. The source 
 - OPPO Watch *(maintained by MagneFire & wannaphong)*
 - Samsung Gear Live *(unmaintained)*
 - Sony Smartwatch 3 *(unmaintained)* Limited support, see <a href="https://asteroidos.org/install/tetra/">install</a> page.
-- Ticwatch E & S *(maintained by kido)*
-- Ticwatch C2+ *(maintained by R0NAM1)*
-- Ticwatch Pro *(maintained by C9Glax, LecrisUT & MagneFire)*
+- TicWatch E & S *(maintained by kido)*
+- TicWatch C2+ *(maintained by R0NAM1)*
+- TicWatch Pro *(maintained by C9Glax, LecrisUT & MagneFire)*
 
 &nbsp;
 #### Possible ports not supported yet:


### PR DESCRIPTION
As pointed out by @dodoradio, there were some errors in the watch branding names for the LG Watch Urbane.

There were some other watch branding errors here and there too. Which should now be corrected as well.