### PR TITLE
sturgeon: Change heart rate sensor status as it broke recently.

### DIFF
--- a/pages/install/sturgeon.md
+++ b/pages/install/sturgeon.md
@@ -14,11 +14,17 @@ layout: aw-install
   <div class="support-col">Haptics<div class="support-col-good"></div></div>
   <div class="support-col">USB<div class="support-col-good"></div></div>
   <div class="support-col">WLAN<div class="support-col-good"></div></div>
-  <div class="support-col">Heart Rate<div class="support-col-good"></div></div>
+  <div class="support-col">Heart Rate<div class="support-col-unknown"></div></div>
   <div class="support-col">Tilt-to-Wake<div class="support-col-good"></div></div>
 </div>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>
     <p>Huawei Watch GT variants are not supported! See the list on the <a href="{{rel 'wiki/porting-status'}}">porting status</a> page to find out if your model is supported.</p>
+</div>
+
+
+<div class="callout callout-warning">
+    <h4>Warning!</h4>
+    <p>It appears that the heart rate sensor has stopped functioning recently. Follow <a href="https://github.com/AsteroidOS/meta-smartwatch/issues/82">https://github.com/AsteroidOS/meta-smartwatch/issues/82</a> to keep yourself informed on the current status of the heart rate sensor.</p>
 </div>


### PR DESCRIPTION
See https://github.com/AsteroidOS/meta-smartwatch/issues/82 for more context.
This changes the heart rate sensor in the support table from green to orange.