### PR TITLE
Use labels, add codenames to header & add tunny to compatiblitity

### DIFF
--- a/pages/install/catfish.md
+++ b/pages/install/catfish.md
@@ -1,7 +1,8 @@
 ---
 title: TicWatch Pro
 deviceName: catfish
-repo: catfish/catfish_ext/catshark
+label: catfish/catfish_ext/catshark
+section: install
 layout: aw-install
 ---
 

--- a/pages/install/firefish.md
+++ b/pages/install/firefish.md
@@ -1,7 +1,7 @@
 ---
 title: Fossil Gen 4
 deviceName: firefish
-repo: ray/firefish
+label: ray/firefish
 section: install
 layout: aw-install
 ---

--- a/pages/install/ray.md
+++ b/pages/install/ray.md
@@ -1,7 +1,7 @@
 ---
 title: Skagen Falster 2
 deviceName: ray
-repo: ray/firefish
+label: ray/firefish
 section: install
 layout: aw-install
 ---

--- a/pages/install/skipjack.md
+++ b/pages/install/skipjack.md
@@ -1,6 +1,7 @@
 ---
-title: TicWatch C2+
+title: TicWatch C2/C2+/S2
 deviceName: skipjack
+label: skipjack/tunny
 layout: aw-install
 ---
 

--- a/pages/install/smelt.md
+++ b/pages/install/smelt.md
@@ -1,5 +1,5 @@
 ---
-title: Moto 360 2015
+title: Moto 360 2015 42mm/46mm
 deviceName: smelt
 label: carp/smelt
 windowsDrivers: https://motorola-global-portal.custhelp.com/euf/assets/downloads/Motorola_Mobile_Drivers_64bit.msi

--- a/pages/install/smelt.md
+++ b/pages/install/smelt.md
@@ -1,7 +1,7 @@
 ---
 title: Moto 360 2015
 deviceName: smelt
-repo: carp/smelt
+label: carp/smelt
 windowsDrivers: https://motorola-global-portal.custhelp.com/euf/assets/downloads/Motorola_Mobile_Drivers_64bit.msi
 section: install
 layout: aw-install

--- a/pages/main/install.md
+++ b/pages/main/install.md
@@ -84,7 +84,7 @@ If you have questions regarding the installation process, please check out the *
 </div></a>
 <a href="{{rel '/install/skipjack'}}"><div class="install-box">
   <img src="{{assets}}/img/skipjack.png" width="100%"><br>
-  <b>TicWatch C2/C2+</b><br>(skipjack)<br>
+  <b>TicWatch C2/C2+/S2</b><br>(skipjack)<br>
   <i>Support: <span class="star-good"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
 </div></a>
 <a href="{{rel '/install/beluga'}}"><div class="install-box">

--- a/templates/includes/install-header.hbs
+++ b/templates/includes/install-header.hbs
@@ -5,6 +5,6 @@
 <g transform="translate(-73.598 -103.17)">
 <g transform="translate(1.6)" fill="#666">
 <path d="m73.598 103.17h0.85725l2.8998 4.8154-2.8998 4.8154h-0.85725l2.8892-4.8154z" fill="#666" stroke-width=".26458"/>
-</g></g></svg> {{ title }} ({{ deviceName }})</h1>
+</g></g></svg> {{ title }} ({{#if label}}{{label}}{{else}}{{deviceName}}{{/if}})</h1>
   </div>
 </div>

--- a/templates/layouts/aw-install-simg.hbs
+++ b/templates/layouts/aw-install-simg.hbs
@@ -14,7 +14,7 @@
       <h1>Hardware Support</h1>
       <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}. The following table should summarize the current support of this watch:</p>
       {{> body }}
-      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label {{#if repo}}{{repo}}{{else}}{{deviceName}}{{/if}} for issues specific to your watch.</p>
+      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label {{#if label}}{{label}}{{else}}{{deviceName}}{{/if}} for issues specific to your watch.</p>
       <h1>Preparation</h1>
       <div class="install-preparation-box">
         <h3>Download AsteroidOS nightly builds</h3>

--- a/templates/layouts/aw-install.hbs
+++ b/templates/layouts/aw-install.hbs
@@ -14,7 +14,7 @@
       <h1>Hardware Support</h1>
       <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}. The following table should summarize the current support of this watch:</p>
       {{> body }}
-      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label <code>{{#if repo}}{{repo}}{{else}}{{deviceName}}{{/if}}</code> for issues specific to your watch.</p>
+      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label <code>{{#if label}}{{label}}{{else}}{{deviceName}}{{/if}}</code> for issues specific to your watch.</p>
       <h1>Preparation</h1>
       <div class="install-preparation-box">
         <h3>Download AsteroidOS nightly builds</h3>

--- a/templates/layouts/beluga-install.hbs
+++ b/templates/layouts/beluga-install.hbs
@@ -14,7 +14,7 @@
       <h1>Hardware Support</h1>
       <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}. The following table should summarize the current support of this watch:</p>
       {{> body }}
-      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label <code>{{#if repo}}{{repo}}{{else}}{{deviceName}}{{/if}}</code> for issues specific to your watch.</p>
+      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label <code>{{#if label}}{{label}}{{else}}{{deviceName}}{{/if}}</code> for issues specific to your watch.</p>
       <h1>Preparation</h1>
       <div class="install-preparation-box">
         <h3>Download AsteroidOS nightly builds</h3>

--- a/templates/layouts/mooneye-install.hbs
+++ b/templates/layouts/mooneye-install.hbs
@@ -14,7 +14,7 @@
       <h1>Hardware Support</h1>
       <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}. The following table should summarize the current support of this watch:</p>
       {{> body }}
-      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label {{#if repo}}{{repo}}{{else}}{{deviceName}}{{/if}} for issues specific to your watch.</p>
+      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label {{#if label}}{{label}}{{else}}{{deviceName}}{{/if}} for issues specific to your watch.</p>
       <h1>Preparation</h1>
       <div class="install-preparation-box">
         <h3>Download AsteroidOS nightly builds</h3>

--- a/templates/layouts/mtk-install.hbs
+++ b/templates/layouts/mtk-install.hbs
@@ -14,7 +14,7 @@
       <h1>Hardware Support</h1>
       <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}. The following table should summarize the current support of this watch:</p>
       {{> body }}
-      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label {{#if repo}}{{repo}}{{else}}{{deviceName}}{{/if}} for issues specific to your watch.</p>
+      <p>You can report any hardware support issue <a href="https://github.com/AsteroidOS/meta-smartwatch/issues">here</a>. Use the label {{#if label}}{{label}}{{else}}{{deviceName}}{{/if}} for issues specific to your watch.</p>
       <h1>Preparation</h1>
       <div class="install-preparation-box">
         <h3>Download AsteroidOS nightly builds</h3>


### PR DESCRIPTION
This PR includes some minor changes.
It consists of renaming the `repo` to `label` as all watch repos have been merged some time ago and `repo` was mis-used for `label`s.
Additionally, it uses the `label` in the header to indicate the compatibility with the different watches.
Adding to that, a bit more detail is added to the page header when it comes to the specific watch.

This fixes https://github.com/AsteroidOS/asteroidos.org/issues/159 and addresses the comment in https://github.com/AsteroidOS/asteroidos.org/pull/158.

Previews:

![Screenshot from 2022-07-11 22-27-40](https://user-images.githubusercontent.com/7857908/178352825-29a26cd3-8f92-4583-a65e-33da30b94e0a.png)

![Screenshot from 2022-07-11 22-27-59](https://user-images.githubusercontent.com/7857908/178352856-2869d9ec-5e64-4ef0-b0f2-1b57f5914be5.png)

![Screenshot from 2022-07-11 22-29-57](https://user-images.githubusercontent.com/7857908/178352858-0a1723fd-5f82-4dfd-9701-15e602400557.png)

![Screenshot from 2022-07-11 22-30-17](https://user-images.githubusercontent.com/7857908/178352862-817dd200-88e6-4052-b28d-471e01271b4a.png)
