### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest
+LABEL maintainer="Ed Beroset <beroset@ieee.org>"
+WORKDIR /tmp/
+RUN apk --no-cache add nodejs git npm lighttpd
+RUN git clone https://github.com/AsteroidOS/asteroidos.org.git
+WORKDIR /tmp/asteroidos.org
+RUN sed -i -e 's#/var/www/localhost#/tmp/asteroidos.org/_asteroidos.org#' /etc/lighttpd/lighttpd.conf
+RUN sed -i -e 's#/htdocs##' /etc/lighttpd/lighttpd.conf
+RUN npm install
+RUN npm i -g grunt
+RUN grunt
+CMD ["lighttpd", "-D", "-f", "/etc/lighttpd/lighttpd.conf"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,24 @@ Assemble and Grunt are used to build the site. To get started:
 
 If all worked properly, you should have your website ready in an `_asteroidos.org` folder
 
+## Using `docker` or `podman`
+
+This can also be built and run inside a container even more simply.
+
+``` Bash
+podman build https://raw.githubusercontent.com/AsteroidOS/asteroidos.org/master/Dockerfile -t asteroidos-docserver
+```
+
+This will create an `asteroidos-docserver` image which is only around 236 MB and based on the Alpine Linux distribution.  To run it locally:
+
+``` Bash
+podman run -p8080:80 asteroidos-docserver
+```
+
+This will run a server in the container which can then be reached on your local machine by pointing your browser to `localhost:8080/`.  
+
+Although `podman` was used here, `docker` command syntax is identical.
+
 ## License
 This website is a fork of lesscss.org
 


### PR DESCRIPTION
This adds a Dockerfile and some description of how to use it to easily build and run a copy of the `asteroidos.org` documentation server within a locally hosted container.