### PR TITLE
Add container docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,38 +4,7 @@
 
 ## Quickstart
 
-Assemble and Grunt are used to build the site. To get started:
-
-1. Make sure you have the following installed:
-   * [NodeJS](https://nodejs.org/en/download/)
-   * [Git](https://git-scm.com/downloads)
-2. Run:
-   ``` Bash
-   git clone https://github.com/AsteroidOS/asteroidos.org.git # Clone this repository
-   cd asteroidos.org # Go to the root of the repo
-   npm install # Install dependencies
-   npx grunt # Build the site (If your npm version is so old that it doesn't support npx, run `npm i -g grunt` followed by `grunt` instead)
-   ```
-
-If all worked properly, you should have your website ready in an `_asteroidos.org` folder
-
-## Using `docker` or `podman`
-
-This can also be built and run inside a container even more simply.
-
-``` Bash
-podman build https://raw.githubusercontent.com/AsteroidOS/asteroidos.org/master/Dockerfile -t asteroidos-docserver
-```
-
-This will create an `asteroidos-docserver` image which is only around 236 MB and based on the Alpine Linux distribution.  To run it locally:
-
-``` Bash
-podman run -p8080:80 asteroidos-docserver
-```
-
-This will run a server in the container which can then be reached on your local machine by pointing your browser to `localhost:8080/`.  
-
-Although `podman` was used here, `docker` command syntax is identical.
+You can build and run a local copy of the web site on your own computer.  See https://asteroidos.org/wiki/localweb/ for details.
 
 ## License
 This website is a fork of lesscss.org

--- a/pages/wiki/documentation.md
+++ b/pages/wiki/documentation.md
@@ -29,6 +29,7 @@ layout: documentation
   <li><a href="{{rel 'wiki/creating-an-asteroid-app'}}">Creating an Asteroid app</a></li>
   <li><a href="{{rel 'wiki/watchfaces-creation'}}">Watchfaces creation</a></li>
   <li><a href="{{rel 'wiki/emulator'}}">Emulator</a></li>
+  <li><a href="{{rel 'wiki/localweb'}}">Local version of asteroidos.org</a></li>
   <li><a href="{{rel 'wiki/ble-profiles'}}">Bluetooth Low Energy Profiles</a></li>
   <li><a href="{{rel 'wiki/conferences'}}">Conferences</a></li>
   <li><a href="{{rel 'wiki/porting-guide'}}">Porting Guide</a></li>

--- a/pages/wiki/localweb.md
+++ b/pages/wiki/localweb.md
@@ -1,0 +1,49 @@
+---
+title: Local version of asteroidos.org
+layout: documentation
+---
+
+This web site can be built and run locally within a software container, such as those created by *container engines* like [Docker](https://www.docker.com/) or [podman](https://podman.io/). One reason for doing this is to be able to install and build the documentation without having to load the collection of tools on your real computer. Building and running a documentation server in a local container is the topic of this page.
+
+# Building the web site
+---
+
+This documentation will use `podman`, but the commands for `docker` are identical. If you wish to use `docker` instead of `podman`, just substitute `docker` for `podman` in each of the commands shown below.
+
+``` Bash
+podman build https://raw.githubusercontent.com/AsteroidOS/asteroidos.org/master/Dockerfile -t asteroidos-website
+```
+
+This will create an `asteroidos-website` image which is only around 236 MB and based on the Alpine Linux distribution.
+
+# Running locally
+---
+
+The commands above are useful for creating the latest version of the web site. This section describes how to make changes to the documentation locally and try them out in a container.
+
+Create a local version of this repository with `git clone https://github.com/AsteroidOS/asteroidos.org.git`. Then go into that directory `cd asteroidos.org`.
+
+``` Bash
+export adoc = $(podman run --rm -dv "$(pwd)":/tmp/asteroidos.org:z \
+    -p8080:80 asteroidos-website)
+```
+
+This will start the container and run it in the background, and assign the number returned to a variable called `adoc`.
+
+``` Bash
+podman exec ${adoc} grunt
+```
+
+This will rebuild the website and you will be able to see it by pointing your browser to `localhost:8080/`.  
+
+If you decide to make changes to your copy of the website, you can make the changes and then rebuild by running `grunt` within the container.
+
+## Running the unmodified version
+
+**Note:** if you want to simply run and view the unmodified version, you can simply use:
+
+``` Bash
+podman run --rm -d -p8080:80 asteroid-website
+```
+
+This will run the version of the website within the container that existed when the container was constructed.


### PR DESCRIPTION
This adds documentation to the web pages for the containerization implemented in https://github.com/AsteroidOS/asteroidos.org/pull/174 
They are technically independent, because they do not modify any of the same files, but it would make more sense to accept this one after #174 is merged.