### PR TITLE
Add sprat (Samsung Galaxy Live) to the experimental installation section.

### DIFF
--- a/pages/install/sprat.md
+++ b/pages/install/sprat.md
@@ -5,7 +5,7 @@ layout: aw-install
 ---
 
 <div class="support-row">
-  <div class="support-col">Display<div class="support-col-good"></div></div>
+  <div class="support-col">Display<div class="support-col-bad"></div></div>
   <div class="support-col">Touch<div class="support-col-good"></div></div>
   <div class="support-col">Microphone<div class="support-col-good"></div></div>
   <div class="support-col">Bluetooth<div class="support-col-good"></div></div>
@@ -13,23 +13,6 @@ layout: aw-install
   <div class="support-col">Haptics<div class="support-col-good"></div></div>
   <div class="support-col">USB<div class="support-col-good"></div></div>
 </div>
-<table width="100%"><thead><tr>
-<th>Display</th>
-<th>Touch</th>
-<th>Microphone</th>
-<th>Bluetooth</th>
-<th>Compass</th>
-<th>Haptics</th>
-<th>USB</th>
-</tr></thead><tbody><tr height="25px">
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#b94a48"></td>
-<td bgcolor="#5ab948"></td>
-<td bgcolor="#5ab948"></td>
-</tr></tbody></table>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>

--- a/pages/main/install.md
+++ b/pages/main/install.md
@@ -119,6 +119,11 @@ The AsteroidOS support level for some watches is currently deemed experimental f
   <b>Moto 360</b><br>(minnow)<br>
   <i>Support: <span class="star-good"><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
 </div></a>
+<a href="{{rel '/install/sprat'}}"><div class="install-box">
+  <img src="{{assets}}/img/sprat.png" width="100%"><br>
+  <b>Samsung Gear Live</b><br>(sprat)<br>
+  <i>Support: <span class="star-good"><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
+</div></a>
 
 <div class="page-header">
   <h1>FAQ</h1>

--- a/pages/main/install.md
+++ b/pages/main/install.md
@@ -109,14 +109,14 @@ The AsteroidOS support level for some watches is currently deemed experimental f
   <b>OPPO Watch</b><br>(beluga)<br>
   <i>Support: <span class="star-good"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></i></span><span class="star-bad"><i class="icon ion-md-star"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
 </div></a>
-<a href="{{rel '/install/minnow'}}"><div class="install-box">
-  <img src="{{assets}}/img/minnow.png" width="100%"><br>
-  <b>Moto 360</b><br>(minnow)<br>
-  <i>Support: <span class="star-good"><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
-</div></a>
 <a href="{{rel '/install/tetra'}}"><div class="install-box">
   <img src="{{assets}}/img/tetra.png" width="100%"><br>
   <b>Sony Smartwatch 3</b><br>(tetra)<br>
+  <i>Support: <span class="star-good"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
+</div></a>
+<a href="{{rel '/install/minnow'}}"><div class="install-box">
+  <img src="{{assets}}/img/minnow.png" width="100%"><br>
+  <b>Moto 360</b><br>(minnow)<br>
   <i>Support: <span class="star-good"><i class="icon ion-md-star"></i></span><span class="star-bad"><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i><i class="icon ion-md-star"></i></span></i>
 </div></a>
 


### PR DESCRIPTION
Increases the stars for `tetra` as support has improved recently.

Brings back `sprat` to the installation page even though it's not really usable. It does bring this port to the attention of potential contributors willing to help in fixing issues with it :smile: 