### PR TITLE
Remove obsolete sturgeon heartrate monitor warning

### DIFF
--- a/pages/install/sturgeon.md
+++ b/pages/install/sturgeon.md
@@ -9,9 +9,3 @@ layout: aw-install
     <h4>Warning!</h4>
     <p>Huawei Watch GT variants are not supported! See the list on the <a href="{{rel 'wiki/porting-status'}}">porting status</a> page to find out if your model is supported.</p>
 </div>
-
-
-<div class="callout callout-warning">
-    <h4>Warning!</h4>
-    <p>It appears that the heart rate sensor has stopped functioning recently. Follow <a href="https://github.com/AsteroidOS/meta-smartwatch/issues/82">https://github.com/AsteroidOS/meta-smartwatch/issues/82</a> to keep yourself informed on the current status of the heart rate sensor.</p>
-</div>


### PR DESCRIPTION
Since issue #82 is now fixed and closed, the warning about the heartrate
monitor not working on sturgeon is now obsolete.  This patch removes
that warning.

Signed-off-by: Ed Beroset <beroset@ieee.org>