### PR TITLE
Maintainers to json

### DIFF
--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -6,6 +6,7 @@
         "Asus Zenwatch 1"
       ],
       "status":"supported",
+      "maintainers": [ "locusf" ],
       "stars":3,
       "features": [
         { "name":"Display", "status":"good" },
@@ -23,6 +24,7 @@
         "LG Watch Urbane"
       ],
       "status":"supported",
+      "maintainers": [ "TheAppleMan", "kido" ],
       "stars":5,
       "features": [
         { "name":"Display", "status":"good" },
@@ -43,6 +45,7 @@
         "OPPO Watch"
       ],
       "status":"experimental",
+      "maintainers": [ "MagneFire", "wannaphong" ],
       "stars":2,
       "features": [
         { "name":"Display", "status":"good" },
@@ -63,11 +66,11 @@
     {
       "name":"catfish",
       "othernames":[ "catfish_ext", "catshark" ],
-      "status":"supported",
       "models": [
         "TicWatch Pro 2018/2020"
       ],
       "status":"supported",
+      "maintainers": [ "C9Glax", "LecrisUT", "MagneFire" ],
       "stars":3,
       "features": [
         { "name":"Display", "status":"good" },
@@ -87,6 +90,7 @@
         "LG G Watch"
       ],
       "status":"supported",
+      "maintainers": [ "kido" ],
       "stars":3,
       "features": [
         { "name":"Display", "status":"good" },
@@ -105,6 +109,7 @@
         "Fossil Gen 4"
       ],
       "status":"supported",
+      "maintainers": [ "dodoradio", "MagneFire" ],
       "stars":3,
       "features": [
         { "name":"Display", "status":"good" },
@@ -124,6 +129,7 @@
         "MTK6580 watches"
       ],
       "status":"supported",
+      "maintainers": [ "kido" ],
       "stars":3,
       "features": [
         { "name":"Display", "status":"good" },
@@ -145,6 +151,7 @@
         "MTK6580 watches"
       ],
       "status":"supported",
+      "maintainers": [ "kido" ],
       "stars":3,
       "features": [
         { "name":"Display", "status":"good" },
@@ -166,6 +173,7 @@
         "LG G Watch R"
       ],
       "status":"supported",
+      "maintainers": [ "atx" ],
       "stars":4,
       "features": [
         { "name":"Display", "status":"good" },
@@ -186,6 +194,7 @@
         "Moto 360"
       ],
       "status":"experimental",
+      "maintainers": [ "MagneFire" ],
       "stars":1,
       "features": [
         { "name":"Display", "status":"good" },
@@ -205,6 +214,7 @@
         "TicWatch E & S"
       ],
       "status":"supported",
+      "maintainers": [ "kido" ],
       "stars":2,
       "features": [
         { "name":"Display", "status":"good" },
@@ -222,6 +232,7 @@
         "LG Watch W7"
       ],
       "status":"supported",
+      "maintainers": [ "dodoradio", "MagneFire" ],
       "stars":3,
       "features": [
         { "name":"Display", "status":"good" },
@@ -242,6 +253,7 @@
         "Skagen Falster 2"
       ],
       "status":"supported",
+      "maintainers": [ "MagneFire" ],
       "stars":3,
       "features": [
         { "name":"Display", "status":"good" },
@@ -263,6 +275,7 @@
         "Huawei Watch 2"
       ],
       "status":"supported",
+      "maintainers": [ "MagneFire", "flocke", "fosspill", "FlorentBrianFoxcorner", "jrt" ],
       "stars":3,
       "features": [
         { "name":"Display", "status":"good" },
@@ -283,6 +296,7 @@
         "TicWatch C2/C2+/S2"
       ],
       "status":"supported",
+      "maintainers": [ "R0NAM1" ],
       "stars":3,
       "features": [
         { "name":"Display", "status":"good" },
@@ -306,6 +320,7 @@
         "Moto 360 2015"
       ],
       "status":"supported",
+      "maintainers": [ "MagneFire" ],
       "stars":4,
       "features": [
         { "name":"Display", "status":"good" },
@@ -325,6 +340,7 @@
         "Asus Zenwatch 2"
       ],
       "status":"supported",
+      "maintainers": [ "Lrs121", "dlandau" ],
       "stars":4,
       "features": [
         { "name":"Display", "status":"good" },
@@ -345,6 +361,7 @@
         "Samsung Gear Live"
       ],
       "status":"experimental",
+      "maintainers": [ ],
       "stars":1,
       "features": [
         { "name":"Display", "status":"good" },
@@ -362,6 +379,7 @@
         "Huawei Watch"
       ],
       "status":"supported",
+      "maintainers": [ "MagneFire" ],
       "stars":5,
       "features": [
         { "name":"Display", "status":"good" },
@@ -382,6 +400,7 @@
         "Asus Zenwatch 3"
       ],
       "status":"supported",
+      "maintainers": [ "anYc" ],
       "stars":2,
       "features": [
         { "name":"Display", "status":"good" },
@@ -400,6 +419,7 @@
         "Sony Smartwatch 3"
       ],
       "status":"experimental",
+      "maintainers": [ ],
       "stars":1,
       "features": [
         { "name":"Display", "status":"good" },
@@ -420,6 +440,7 @@
         "Asus Zenwatch 2"
       ],
       "status":"supported",
+      "maintainers": [ "Lrs121", "dlandau" ],
       "stars":4,
       "features": [
         { "name":"Display", "status":"good" },

--- a/pages/wiki/porting-status.md
+++ b/pages/wiki/porting-status.md
@@ -9,47 +9,30 @@ This page aims at gathering info about the currently supported platforms and por
 
 The WearOS smartwatches are the most widespread and easy to support. The source code of their kernels is usually easily available and the drivers can be supported with [libhybris](https://github.com/libhybris/libhybris). Those watches are the current priority of AsteroidOS.
 
-&nbsp;
-#### Supported watches and other ports:
-- [Asus Zenwatch 1 - anthias]({{rel 'install/anthias)'}}
-  - *maintained by locusf*
-- Asus Zenwatch 2 [1,63" - sparrow]({{rel 'install/sparrow'}}) / [1,45" - wren]({{rel 'install/wren)'}}
-  - *maintained by Lrs121 & dlandau*
-- [Asus Zenwatch 3 - swift]({{rel 'install/swift)'}}
-  - *maintained by anYc*
-- [Fossil Gen 4 - firefish]({{rel 'install/firefish)'}}
-  - *maintained by dodoradio & MagneFire*
-- [Huawei Watch - sturgeon]({{rel 'install/sturgeon)'}}
-  - maintained by MagneFire*
-- [Huawei Watch 2 - sawfish/sawshark]({{rel 'install/sawfish)'}}
-  - *maintained by MagneFire, flocke, fosspill, FlorentBrianFoxcorner, jrt and the community*
-- [LG G Watch - dory]({{rel 'install/dory)'}}
-  - *maintained by kido*
-- [LG G Watch R - lenok]({{rel 'install/lenok)'}}
-  - *maintained by atx*
-- [LG Watch Urbane - bass]({{rel 'install/bass) '}}
-  - *maintained by TheAppleMan & kido*
-- [LG Watch W7 - narwhal]({{rel 'install/narwhal)'}}
-  - *maintained by dodoradio & MagneFire*
-- [Moto 360 (1st gen) - minnow]({{rel 'install/minnow)'}}
-  - *maintained by MagneFire*
-- [Moto 360 (2nd gen) - carp/smelt]({{rel 'install/smelt)'}}
-  - *maintained by MagneFire*
-- [OPPO Watch (41/46mm) - beluga]({{rel 'install/beluga)'}}
-  - *maintained by MagneFire & wannaphong*
-- [Skagen Falster 2 - ray]({{rel 'install/ray)'}}
-  - *maintained by MagneFire* 
-- [Sony Smartwatch 3 - tetra]({{rel 'install/tetra)'}}
+### Supported watches
+
+{{#each (getAllWithStatus "supported")}}
+- <a href="../../install/{{name}}">{{models}} ({{name}})</a>
+{{#if maintainers}}
+  - maintained by {{maintainers}}
+{{else}}
   - *unmaintained*
-- [Ticwatch E & S - mooneye]({{rel 'install/mooneye)'}}
-  - *maintained by kido*
-- [Ticwatch C2/C2+/S2 - skipjack]({{rel 'install/skipjack)'}}
-  - *maintained by R0NAM1*
-- [Ticwatch Pro - catfish/catfish_ext/catshark]({{rel 'install/catfish)'}}
-  - *maintained by C9Glax, LecrisUT & MagneFire*
+{{/if}}
+{{/each}}
+
+### Experimental watches
+
+{{#each (getAllWithStatus "experimental")}}
+- <a href="../../install/{{name}}">{{models}} ({{name}})</a>
+{{#if maintainers}}
+  - maintained by {{maintainers}}
+{{else}}
+  - *unmaintained*
+{{/if}}
+{{/each}}
 
 &nbsp;
-#### Possible ports not supported yet:
+### Possible ports not yet supported
 
 - Casio Smart Outdoor Watch
 - Diesel Full Guard (pinouts are on the inside)
@@ -74,7 +57,7 @@ The WearOS smartwatches are the most widespread and easy to support. The source 
 - ZTE Quartz
 
 &nbsp;
-#### Impossible ports because of lack of pinouts:
+### Impossible ports because of lack of pinouts
 - Fossil Q Control
 - Fossil Q Founder
 - Fossil Q Marshal
@@ -93,7 +76,7 @@ The WearOS smartwatches are the most widespread and easy to support. The source 
 - Skagen Falster
 
 &nbsp;
-#### Impossible ports due to unmet hardware dependencies:
+### Impossible ports due to unmet hardware dependencies
 
 - Honor Magic Watch 2
 - Huawei Watch GT


### PR DESCRIPTION
This is the final consolidation of watch info for #176 which adds the list of maintainers to the json file and restructures the porting status page to use data from the json file rather than duplicating it.