### PR TITLE
Tell users to set time before using opkg

### DIFF
--- a/pages/wiki/update-asteroidos.md
+++ b/pages/wiki/update-asteroidos.md
@@ -9,11 +9,11 @@ As currently no AsteroidOS watch has access to the internet by stock means, no G
 
 # Upgrade using OPKG
 
-*****
+Set the correct time and date on the watch. AsteroidOS needs to validate the remote server's certificate and establish a secure connection.
 
-If you don't want to loose your personal data, and prefer upgrading Asteroid without reflashing it, you have two options to establish an internet connection from the watch.
+If you don't want to lose your personal data, and prefer upgrading Asteroid without reflashing it, you have two options to establish an internet connection from the watch.
 
-In case your watch supports WLAN, connect it to your local Wi-Fi network using <code>connmanctl</code> as described on the [IP Connection page]({{rel 'wiki/ip-connection/). Alternatively you can share your internet connection from a PC to the watch via USB. '}}
+In case your watch supports WLAN, connect it to your local Wi-Fi network using `connmanctl` as described on the [IP Connection page]({{rel 'wiki/ip-connection/). Alternatively you can share your internet connection from a PC to the watch via USB. '}}
 
 Once your watch can connect to the internet, you can use AsteroidOS' package manager: `opkg`
 
@@ -22,11 +22,16 @@ The standard commands to upgrade are:
     opkg update
     opkg upgrade
 
+## Common problems
 
+If you get messages like these, it's most likely because the time or date (or both) are not set correctly.
+
+```
+Downloading https://release.asteroidos.org/nightlies/ipk/all/Packages.gz.
+ * opkg_validate_cached_file: Failed to download https://release.asteroidos.org/nightlies/ipk/all/Packages.gz headers: SSL peer certificate or SSH remote key was not OK.
+```
 
 # Reflash AsteroidOS
-
-*****
 
 When no IP connection can be established on your watch, the easiest way to upgrade is to reflash the entire OS following the usual [installation instructions](https://asteroidos.org/install/).
 


### PR DESCRIPTION
It's common for users to report a problem trying to update with opkg
that is a result of not having the correct date and time set on the
watch before using opkg so that the watch can validate the SSL peer
certificate of the server.  This adds that note to the instructions and
also shows the error message that results if one fails to follow them.

Signed-off-by: Ed Beroset <beroset@ieee.org>