### PR TITLE
Add some spaces when printing the maintainers list

### DIFF
--- a/pages/wiki/porting-status.md
+++ b/pages/wiki/porting-status.md
@@ -14,7 +14,7 @@ The WearOS smartwatches are the most widespread and easy to support. The source 
 {{#each (getAllWithStatus "supported")}}
 - <a href="../../install/{{name}}">{{models}} ({{name}})</a>
 {{#if maintainers}}
-  - maintained by {{maintainers}}
+  - maintained by {{#maintainers}}{{#if @index}}, {{/if}}{{.}}{{/maintainers}}
 {{else}}
   - *unmaintained*
 {{/if}}


### PR DESCRIPTION
On the porting-status page, when maintainers are listed, they are listed with no space between the names; there is only a comma.  This adds a space after each comma to make the list easier to read and more pleasing in layout.  Suggested by DocGalaxyBlock on matrix chat.

Signed-off-by: Ed Beroset <beroset@ieee.org>