### PR TITLE
Add support for "partial" as a status

### DIFF
--- a/styles/components/install-support-table.less
+++ b/styles/components/install-support-table.less
@@ -45,6 +45,10 @@ td.support-col-unknown {
   min-width: 30px;
 }
 
+td.support-col-partial {
+  min-width: 30px;
+}
+
 td.support-col-na {
   min-width: 30px;
 }
@@ -55,6 +59,11 @@ td.support-col-na {
 }
 
 .support-col-unknown {
+  height: 25px;
+  background-color: #3366ff;
+}
+
+.support-col-partial {
   height: 25px;
   background-color: #ffa31a;
 }


### PR DESCRIPTION
The currently supported status categories for watch features are "good", "bad", "unknown", and "na", but a discussion on matrix had multiple people asking about the possibility of a "partial" status.  This changes the yellow-orange color previously used for "unknown" to signify "partial" and uses a blue color for "unknown".

Signed-off-by: Ed Beroset <beroset@ieee.org>