### PR TITLE
featurelist: Fix issue where unified watches would link to old install pages.

### DIFF
--- a/templates/layouts/featuretable.hbs
+++ b/templates/layouts/featuretable.hbs
@@ -17,14 +17,14 @@
       {{/each}} 
       </tr>
       {{#each (getAllWithStatus "supported")}}
-        <tr class="support-row"><td class="name-col"><a href="../{{name}}">{{name}}</a></td>
+        <tr class="support-row"><td class="name-col"><a href="../{{#if reference}}{{reference}}{{else}}{{name}}{{/if}}">{{name}}</a></td>
           {{#each (getAugmentedFeatures this (getAllFeatures))}}
               <td class="support-col-{{.}}"></td>
           {{/each}}
         </tr>
       {{/each}}
       {{#each (getAllWithStatus "experimental")}}
-        <tr class="support-row"><td class="name-col"><a href="../{{name}}"><mark>{{name}}</mark></a></td>
+        <tr class="support-row"><td class="name-col"><a href="../{{#if reference}}{{reference}}{{else}}{{name}}{{/if}}"><mark>{{name}}</mark></a></td>
           {{#each (getAugmentedFeatures this (getAllFeatures))}}
               <td class="support-col-{{.}}"></td>
           {{/each}}


### PR DESCRIPTION
https://github.com/AsteroidOS/asteroidos.org/pull/191 has merged similar watches into a single page. This meant that the old pages are no longer valid and from now on they should refer to the merged page.

This fixes the issue where https://asteroidos.org/install/features/ would still link to `wren` and `ray` pages even though they are no longer valid.

This bug was reported by @docgalaxyblock