### PR TITLE
porting-status: Fix issue where unified watches would link to old install pages.

### DIFF
--- a/pages/wiki/porting-status.md
+++ b/pages/wiki/porting-status.md
@@ -12,7 +12,7 @@ The WearOS smartwatches are the most widespread and easy to support. The source 
 ### Supported watches
 
 {{#each (getAllWithStatus "supported")}}
-- <a href="../../install/{{name}}">{{models}} ({{name}})</a>
+- <a href="../../install/{{#if reference}}{{reference}}{{else}}{{name}}{{/if}}">{{models}} ({{name}})</a>
 {{#if maintainers}}
   - maintained by {{#maintainers}}{{#if @index}}, {{/if}}{{.}}{{/maintainers}}
 {{else}}
@@ -23,7 +23,7 @@ The WearOS smartwatches are the most widespread and easy to support. The source 
 ### Experimental watches
 
 {{#each (getAllWithStatus "experimental")}}
-- <a href="../../install/{{name}}">{{models}} ({{name}})</a>
+- <a href="../../install/{{#if reference}}{{reference}}{{else}}{{name}}{{/if}}">{{models}} ({{name}})</a>
 {{#if maintainers}}
   - maintained by {{maintainers}}
 {{else}}


### PR DESCRIPTION
https://github.com/AsteroidOS/asteroidos.org/pull/191 has merged similar watches into a single install page.
This meant that the old pages are no longer valid and from now on they should refer to the merged page.

This bug was reported by @docgalaxyblock (Thank you for doing so :+1: )