### PR TITLE
Update emulator instructions

### DIFF
--- a/pages/wiki/emulator.md
+++ b/pages/wiki/emulator.md
@@ -15,26 +15,24 @@ If you want more control over your asteroid image, you can also [build AsteroidO
 
 # Get an appropriate version of QEMU
 
-The AsteroidOS emulator image requires a paravirtualized GPU only offered by QEMU when built with support for Virgil3D. Recent distribitions (such as Fedora 27) offer QEMU packages built with Virgil and can be used directly to run AsteroidOS.
+The AsteroidOS emulator image requires a paravirtualized GPU only offered by QEMU when built with support for Virgil3D. Recent distribitions (such as Fedora 27 and later) offer QEMU packages built with Virgil and can be used directly to run AsteroidOS.
 
 Unfortunately, most Linux distributions (such as Debian) still do not provide QEMU packages with support for this setup. Moreover, OpenEmbedded currently offers no clean way to build a host QEMU binary with Virgil due to various constraints. You then need to compile QEMU yourself.
-
-**TODO:** Test and integrate a set of QEMU build instructions like the ones provided by [the Genivi project](https://at.projects.genivi.org/wiki/display/GDP/QEMU+with+hardware+graphics+acceleration#QEMUwithhardwaregraphicsacceleration-Compiling).
 
 # Run AsteroidOS
 
 Once you have a correct version of QEMU, a rootfs and a kernel, you can start AsteroidOS in an emulator using:
 
 ```bash
-qemu-system-x86-64 -enable-kvm -kernel bzImage-qemux86.bin \
--device virtio-vga,virgl=on \
--net nic -net user,hostfwd=tcp::2222-:22 \
--drive format=raw,file=asteroid-image-qemux86.ext4 \
--m 512 \
--display sdl,gl=on \
--cpu qemu64,+ssse3,+sse4.1,+sse4.2 \
--device usb-mouse -machine usb=on \
---append "quiet root=/dev/hda rw mem=512M video=800x800"
+qemu-system-x86_64 -enable-kvm -kernel bzImage-qemux86.bin \
+    -device virtio-vga-gl \
+    -net nic -net user,hostfwd=tcp::2222-:22 \
+    -drive format=raw,file="asteroid-image-qemux86.ext4" \
+    -m 512 \
+    -display sdl,gl=on \
+    -cpu qemu64,+ssse3,+sse4.1,+sse4.2 \
+    -device usb-mouse -machine usb=on \
+    --append "verbose root=/dev/sda rw mem=512M video=800x800"
 ```
 
 The previous command sets up a port forwarding so that you can connect to the emulator using SSH with the following command:
@@ -46,8 +44,8 @@ ssh -p 2222 ceres@localhost
 # Troubleshooting
 Here are some common problems and their solutions.
 
-## `qemu-system-x86: -device virtio-vga,virgl=on: Property 'virtio-vga.virgl' not found`
-Newer versions of QEMU use `-device virtio-vga-gl` instead of `-device virtio-vga,virgl=on`, so if you get this message, use the newer form.
+## Errors with `-virtio-vga`
+Newer versions of QEMU use `-device virtio-vga-gl` instead of `-device virtio-vga,virgl=on`, so if you get an error message complaining about `virtio-vga-gl`, you have an earlier version of QEMU.  You can either use `-device virtio-vga,virgl=on` instead or upgrade to a newer version of QEMU.
 
 ## Video corruption using NVIDIA drivers
 There have been reported problems on machines using proprietary NVIDIA drivers.  One symptom is a black screen instead of the AsteroidOS screen which may or may not also show messages like these:


### PR DESCRIPTION
This fixes a typo, adds some specifics relevant to newer versions of QEMU (that is, we now treat new versions as the norm and old versions as the exception) and removes a TODO note that points to a dead link.

Signed-off-by: Ed Beroset <beroset@ieee.org>