### PR TITLE
Update dory's page

### DIFF
--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -105,14 +105,14 @@
         "LG G Watch"
       ],
       "status":"supported",
-      "maintainers": [ "kido" ],
-      "stars":3,
+      "maintainers": [ "kido", "MagneFire" ],
+      "stars":4,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
         { "name":"Bluetooth", "status":"good" },
         { "name":"Haptics", "status":"good" },
-        { "name":"Tilt-to-Wake", "status":"bad" },
+        { "name":"Tilt-to-Wake", "status":"good" },
         { "name":"Always-on-Display", "status":"good" },
         { "name":"Microphone", "status":"good" },
         { "name":"Compass", "status":"good" },


### PR DESCRIPTION
Updates the install page of `dory` to include @MagneFire's [improvements](https://github.com/AsteroidOS/meta-smartwatch/pull/148):
- tilt-to-wake
- adds @MagneFire as a maintainer
- increases dory to 4 stars (previously 3)