### PR TITLE
[Install pages ]Add all known model numbers and polish install pages

### DIFF
--- a/pages/install/anthias.md
+++ b/pages/install/anthias.md
@@ -3,3 +3,7 @@ title: Asus Zenwatch 1
 deviceName: anthias
 layout: aw-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>WI500Q</p>
+</div>

--- a/pages/install/bass.md
+++ b/pages/install/bass.md
@@ -4,6 +4,10 @@ deviceName: bass
 section: install
 layout: aw-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>W150</p>
+</div>
 
 <div class="callout callout-info">
     <h4>Heart rate sensor not working?</h4>

--- a/pages/install/beluga.md
+++ b/pages/install/beluga.md
@@ -4,6 +4,12 @@ deviceName: beluga
 section: install
 layout: beluga-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>OW19W6 - OPPO Watch 41mm Wifi (beluga)</p>
+    <p>OW19W8 - OPPO Watch 46mm Wifi (beluga)</p>
+    <p>OW19W12 - OPPO Watch 46mm LTE (belugaxl)</p>
+</div>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>

--- a/pages/install/catfish.md
+++ b/pages/install/catfish.md
@@ -5,3 +5,9 @@ label: catfish/catfish_ext/catshark
 section: install
 layout: aw-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>WF11018 - TicWatch Pro LTE (catfish-ext)</p>
+    <p>WF12096 - TicWatch Pro 2018 (catfish)</p>
+    <p>WF12106 - TicWatch Pro 2020 (catshark)</p>
+</div>

--- a/pages/install/dory.md
+++ b/pages/install/dory.md
@@ -3,3 +3,7 @@ title: LG G Watch
 deviceName: dory
 layout: aw-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>W100</p>
+</div>

--- a/pages/install/firefish.md
+++ b/pages/install/firefish.md
@@ -5,26 +5,28 @@ label: ray/firefish
 section: install
 layout: aw-install-multi
 ---
-
-<div class="callout callout-warning">
-    <h4>Variants</h4>
+<div class="callout callout-info">
+    <h4>Model number and variants</h4>
+    <p></p>
+    <p></p>
     <p>The Fossil Gen 4 is marketed as different versions from different manufacturers.
     This means that there are two known versions that are compatible with a range of Fossil Gen 4 watches.
-    These two versions will be referred to as: <code>ray</code> and <code>firefish</code></p>
-    <code>firefish</code> is compatible with the following variants:
+    These two versions are referred to as: <code>ray</code> and <code>firefish</code></p>
+    <p></p>
+    DW6XX - <code>firefish</code> is compatible with the following variants:
     <ul>
-        <li>Fossil Q Explorist HR</li>
-        <li>Diesel On Full Guard 2.5</li>
-        <li>Misfit Vapor 2 (46mm)</li>
-        <li>Others with the <code>DW6xx</code> model name</li>
+        <li>DW6B1 - Misfit Vapor 2 (46mm)</li>
+        <li>DW6xx - Fossil Q Explorist HR</li>
+        <li>DW6xx - Diesel On Full Guard 2.5</li>
+        <li>And other variants with model number DW6xx</li>
     </ul>
-    <code>ray</code> is compatible with the following variants:
+    DW7XX - <code>ray</code> is compatible with the following variants:
     <ul>
-        <li>Fossil Q Venture HR</li>
-        <li>Skagen Falster 2</li>
-        <li>Misfit Vapor 2 (41mm)</li>
-        <li>Michael Kors Access Runway</li>
-        <li>Others with the <code>DW7xx</code> model name</li>
+        <li>DW7F1 - Fossil Q Venture HR</li>
+        <li>DW7S1 - Skagen Falster 2</li>
+        <li>DW7xx - Misfit Vapor 2 (41mm)</li>
+        <li>DW7xx - Michael Kors Access Runway</li>
+        <li>And other variants with model number DW7xx</li>
     </ul>
 </div>
 

--- a/pages/install/lenok.md
+++ b/pages/install/lenok.md
@@ -3,3 +3,7 @@ title: LG G Watch R
 deviceName: lenok
 layout: aw-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>W110</p>
+</div>

--- a/pages/install/mooneye.md
+++ b/pages/install/mooneye.md
@@ -3,3 +3,8 @@ title: TicWatch E & S
 deviceName: mooneye
 layout: mooneye-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>WF12086 - TicWatch E (mooneye)</p>
+    <p>WF12066 - TicWatch S (mooneye)</p>
+</div>

--- a/pages/install/narwhal.md
+++ b/pages/install/narwhal.md
@@ -4,6 +4,10 @@ deviceName: narwhal
 section: install
 layout: aw-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>LM-W315</p>
+</div>
 
 <div class="callout callout-warning">
     <p>This watch has a pair of physical hands embedded between the display and touchscreen panel. This obviously compromises the usability of the interface as the hands are a permanent obstruction. If you do not own one already, it is recommended to do a lot of research before buying.</p>

--- a/pages/install/sawfish.md
+++ b/pages/install/sawfish.md
@@ -4,6 +4,11 @@ deviceName: sawfish
 section: install
 layout: aw-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>LEO-BX9 - Huawei Watch 2 (Sawfish)</p>
+    <p>LEO-DLXX - Huawei Watch 2 LTE (Sawshark)</p>
+</div>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>

--- a/pages/install/skipjack.md
+++ b/pages/install/skipjack.md
@@ -1,5 +1,5 @@
 ---
-title: TicWatch C2/C2+/S2
+title: TicWatch C2/C2+/S2/E2
 deviceName: skipjack
 label: skipjack/tunny
 layout: aw-install

--- a/pages/install/skipjack.md
+++ b/pages/install/skipjack.md
@@ -4,4 +4,9 @@ deviceName: skipjack
 label: skipjack/tunny
 layout: aw-install
 ---
-
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>WG12016 - TicWatch S2 (tunny)</p>
+    <p>WG12026 - TicWatch E2 (tunny)</p>
+    <p>WG12036 - TicWatch C2/C2+ (skipjack)</p>
+</div>

--- a/pages/install/smelt.md
+++ b/pages/install/smelt.md
@@ -6,6 +6,13 @@ windowsDrivers: https://motorola-global-portal.custhelp.com/euf/assets/downloads
 section: install
 layout: aw-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>360L - Moto 360 2nd gen, 46mm, 20mm (smelt)</p>
+    <p>360S - Moto 360 2nd gen, 42mm, 18mm (carp)</p>
+    <p>360W - Moto 360 2nd gen, 42mm, 16mm (carp)</p>
+    <p>360SP - Moto 360 sports (sportscarp)</p>
+</div>
 
 <div class="callout callout-info">
     <p>GPS is only available on the Moto 360 Sport</p>

--- a/pages/install/sparrow.md
+++ b/pages/install/sparrow.md
@@ -4,6 +4,11 @@ deviceNames: [sparrow, wren]
 label: sparrow/wren
 layout: aw-install-multi
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>WI501Q - Asus ZenWatch 2, 46mm (sparrow)</p>
+    <p>WI502Q - Asus ZenWatch 2, 41mm (wren)</p>
+</div>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>

--- a/pages/install/sprat.md
+++ b/pages/install/sprat.md
@@ -3,6 +3,10 @@ title: Samsung Gear Live
 deviceName: sprat
 layout: aw-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>SM-R382</p>
+</div>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>

--- a/pages/install/swift.md
+++ b/pages/install/swift.md
@@ -3,3 +3,7 @@ title: Asus Zenwatch 3
 deviceName: swift
 layout: aw-install
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>WI503Q</p>
+</div>

--- a/pages/install/tetra.md
+++ b/pages/install/tetra.md
@@ -3,6 +3,10 @@ title: Sony Smartwatch 3
 deviceName: tetra
 layout: aw-install-simg
 ---
+<div class="callout callout-info">
+    <h4>Model number</h4>
+    <p>SWR50</p>
+</div>
 
 <div class="callout callout-warning">
     <h4>Warning!</h4>

--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -329,7 +329,7 @@
       "name":"skipjack",
       "othernames":[ "tunny" ],
       "models": [
-        "TicWatch C2/C2+/S2"
+        "TicWatch C2/C2+/S2/E2"
       ],
       "status":"supported",
       "maintainers": [ "R0NAM1" ],

--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -271,7 +271,7 @@
         { "name":"Microphone", "status":"good" },
         { "name":"Compass", "status":"good" },
         { "name":"USB", "status":"good" },
-        { "name":"WLAN", "status":"good" },
+        { "name":"WLAN", "status":"bad" },
         { "name":"Hands", "status":"bad" }
       ]
     },


### PR DESCRIPTION
This PR aims to integrate the model numbers for most of the watches to their install pages, like noted in this issue:
https://github.com/AsteroidOS/asteroidos.org/issues/193
All model numbers have been researched to be correct. Multiple sources per search for each code where easily verifiable.
The advantage of listing the model numbers are:
- Users can better identify and verify the system image for the watch they are owning.
- Purchases on second hand market often yield much better results when adding the model number.
- Search engines will index the model numbers and list us in searches accordingly.

This PR also fixes the narwhal wlan feature matrix to "bad".
And adds E2 tunny to the install main page and feature matrix name for skipjack.

Currently model numbers for following watches are missing:
- minnow [moto 360 gen 1]
- sturgeon [Huawei Watch]
- harmony/inharmony

I decided to add a blue infobox as wrapper. Thanks to @MagneFire and @dodoradio for giving valuable input on the layout.
The current approach only repeats watch names when necessary to differentiate variants. For watches with only one variant, only the model number is shown.
Compare a complex case in firefish/ray:
![grafik](https://user-images.githubusercontent.com/15074193/218592882-07397615-eaab-4c43-8e1c-d70437cc58e9.png)

or OPPO Watch
![grafik](https://user-images.githubusercontent.com/15074193/218593299-17384e18-6b01-4248-8b66-82997dd767e5.png)

With e.g. narwhal:
![grafik](https://user-images.githubusercontent.com/15074193/218593009-61048e9d-6d78-4f7c-bac4-67f2aa97a6e5.png)

