### PR TITLE
Add info fix typo

### DIFF
--- a/pages/install/firefish.md
+++ b/pages/install/firefish.md
@@ -12,7 +12,7 @@ layout: aw-install-multi
     This means that there are two known versions that are compatible with a range of Fossil Gen 4 watches.
     These two versions are referred to as <code>firefish</code> and <code>ray</code>.  One difference between the two is that <code>firefish</code> has a larger display than <code>ray</code>.
     </p><p>
-    Generally, models that start with DW6 have a are compatible with <code>firefish</code> and models that start with DW7 are compatible with <code>ray</code>.
+    Generally, models that start with DW6 are compatible with <code>firefish</code>. Models that start with DW7 are compatible with <code>ray</code>.
     </p>
 </div>
 

--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -509,7 +509,7 @@
         "Huawei Watch"
       ],
       "modelnumbers": [
-        { "num":"Huawei Watch", "name":"Huawei Watch", "codename":"sturgeon" }
+        { "num":"W1", "name":"Huawei Watch", "codename":"sturgeon" }
       ],
       "status":"supported",
       "maintainers": [ "MagneFire" ],

--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -145,8 +145,8 @@
       ],
       "modelnumbers": [
         { "num":"DW6B1", "name":"Misfit Vapor 2 (46mm)", "codename":"firefish" },
-        { "num":"DW6xx", "name":"Fossil Q Explorist HR", "codename":"firefish" },
-        { "num":"DW6xx", "name":"Diesel On Full Guard 2.5", "codename":"firefish" },
+        { "num":"DW6F1", "name":"Fossil Q Explorist HR Gen4", "codename":"firefish" },
+        { "num":"DW6D1", "name":"Diesel On Full Guard 2.5", "codename":"firefish" },
         { "num":"DW7F1", "name":"Fossil Q Venture HR", "codename":"ray" },
         { "num":"DW7S1", "name":"Skagen Falster 2", "codename":"ray" },
         { "num":"DW7xx", "name":"Misfit Vapor 2 (41mm)", "codename":"ray" },

--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -149,8 +149,8 @@
         { "num":"DW6D1", "name":"Diesel On Full Guard 2.5", "codename":"firefish" },
         { "num":"DW7F1", "name":"Fossil Q Venture HR", "codename":"ray" },
         { "num":"DW7S1", "name":"Skagen Falster 2", "codename":"ray" },
-        { "num":"DW7xx", "name":"Misfit Vapor 2 (41mm)", "codename":"ray" },
-        { "num":"DW7xx", "name":"Michael Kors Access Runway", "codename":"ray" }
+        { "num":"DW7B1", "name":"Misfit Vapor 2 (41mm)", "codename":"ray" },
+        { "num":"DW7M1", "name":"Michael Kors Access Runway", "codename":"ray" }
       ],
       "status":"supported",
       "maintainers": [ "dodoradio", "MagneFire" ],

--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -144,13 +144,21 @@
         "Fossil Gen 4"
       ],
       "modelnumbers": [
+        { "num":"DW6A1", "name":"Armani Exchange Connected Drexler", "codename":"firefish" },
         { "num":"DW6B1", "name":"Misfit Vapor 2 (46mm)", "codename":"firefish" },
         { "num":"DW6F1", "name":"Fossil Q Explorist HR Gen4", "codename":"firefish" },
         { "num":"DW6D1", "name":"Diesel On Full Guard 2.5", "codename":"firefish" },
-        { "num":"DW7F1", "name":"Fossil Q Venture HR", "codename":"ray" },
-        { "num":"DW7S1", "name":"Skagen Falster 2", "codename":"ray" },
         { "num":"DW7B1", "name":"Misfit Vapor 2 (41mm)", "codename":"ray" },
-        { "num":"DW7M1", "name":"Michael Kors Access Runway", "codename":"ray" }
+        { "num":"DW7E1", "name":"Emporio Armani Connected Matteo", "codename":"ray" },
+        { "num":"DW7E2", "name":"Emporio Armani Connected Alberto 2018", "codename":"ray" },
+        { "num":"DW7F1", "name":"Fossil Q Venture HR Gen4", "codename":"ray" },
+        { "num":"DW7F2", "name":"Fossil Q Sloan HR Gen 4", "codename":"ray" },
+        { "num":"DW7K1", "name":"Kate Spade Scallop Smartwatch 2", "codename":"ray" },
+        { "num":"DW7M1", "name":"Michael Kors Access Runway", "codename":"ray" },
+        { "num":"DW7M2", "name":"Michael Kors Access Sofie HR", "codename":"ray" },
+        { "num":"DW7S1", "name":"Skagen Falster 2", "codename":"ray" },
+        { "num":"DW7T1", "name":"Tory Burch ToryTrack Gigi", "codename":"ray" },
+        { "num":"DW7T2", "name":"Tory Burch ToryTrack Tory", "codename":"ray" }
       ],
       "status":"supported",
       "maintainers": [ "dodoradio", "MagneFire" ],


### PR DESCRIPTION
Found an italian source with all DW6xx and DW7xx models listed. Updated the firefish/ray model numbers.
https://orologismartwatch.com/fossil-dw6-platform
https://orologismartwatch.com/fossil-dw7-platform

Also found that W1 is used a lot for sturgeon.