### PR TITLE
Rework FAQ

### DIFF
--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -69,6 +69,9 @@ Or check the [features table]({{rel 'install/features'}}) to see a matrix of all
 Maybe in the future. See the [porting status]({{rel 'wiki/porting-status'}}) page for details on what kinds of watches might be supported in the future and what the general requirements are for running AsteroidOS.\
 If you are interested in porting AsteroidOS to a new watch yourself, please read the [Porting Guide] ({{rel 'wiki/porting-guide'}}) page and contact us via our [matrix channel]({{rel 'contact'}}) in case of possible questions.
 
+## I do not want to flash a prebuilt image on my watch. Can I compile AsteroidOS myself?
+Review the [Building AsteroidOS]({{rel 'wiki/building-asteroidos'}}) page for detailed instructions on how to compile AsteroidOS yourself.
+
 ## Will I be able to revert to the previous operating system after installing AsteroidOS on my watch?
 Yes, very easily if you choose the "temporary install" option.\
 For most watches, you may choose to only temporarily install AsteroidOS alongside the existing OS, called a "dual-boot". When doing so, the `asteroidos.ext4` image is pushed to the userdata partition using ADB. With no alteration to the previous OS. The downside of this method being, AsteroidOS needs to be manually booted using `fastboot boot boot-image.fastboot` while connected via USB, after every reboot or shutdown. Else, the previous OS will start up as usual.\

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -15,26 +15,26 @@ Currently, AsteroidOS has these features available:
  - Always-on-Display
  - Tilt-to-Wake
  - Palm-to-Sleep
- - phone notifications
- - multiple app launcher styles
- - wallpapers
- - [community watchfaces](https://github.com/AsteroidOS/unofficial-watchfaces)
- - nightstand mode
+ - Phone notifications
+ - Multiple app launcher styles
+ - Wallpapers
+ - [Community watchfaces](https://github.com/AsteroidOS/unofficial-watchfaces)
+ - Nightstand mode
 
 ## Does AsteroidOS have any apps included?
 The following apps are delivered with an AsteroidOS installation:
- - agenda, a calendar
- - alarm clock
- - calculator
- - compass
- - diamonds game
- - flashlight
- - heartrate check
- - music, a media remote control
- - settings
- - stopwatch
- - timer
- - weather forecast
+ - Agenda, a calendar
+ - Alarm clock
+ - Calculator
+ - Compass
+ - Diamonds game
+ - Flashlight
+ - Heartrate check
+ - Music, a media remote control
+ - Settings
+ - Stopwatch
+ - Timer
+ - Weather forecast
 
 ## Is there something like a "Play Store" to download apps?
 Not yet, but this is something that is being considered for future implementation. There are a number of contributed apps that are not installed in the default image. These can be [installed manually]({{rel 'wiki/package-installation/#packageinstallation'}}) if desired.
@@ -72,10 +72,10 @@ Yes, if you choose the "temporary install" option. See the [installation FAQ]({{
 
 ## What features and apps does AsteroidOS currently **not** provide?
 There are a great many more *ideas* for apps than apps at the moment. Some of the more commonly requested, but not yet available applications and features are:
- - call answering from the watch
- - fitness and health tracking application (step counter, ongoing heartrate monitor, etc.)
- - support for using the watch as a phone (for some watches that incorporate a cellular phone chip)
- - *and many more*
+ - Call answering from the watch
+ - Fitness and health tracking application (step counter, ongoing heartrate monitor, etc.)
+ - Support for using the watch as a phone (for some watches that incorporate a cellular phone chip)
+ - *And many more*
 
 Some of these are being worked on, and others are just ideas at this point. If you think you might like to contribute, see our [GitHub repository](https://github.com/AsteroidOS/asteroid/issues) and the [Contact]({{rel 'contact'}}) page. There are many opportunities for creativity!
 

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -35,6 +35,12 @@ The following apps are delivered with an AsteroidOS installation:
  - timer
  - weather forecast
 
+## Where can I find a phone synchronization app?
+A phone is not *required* to use AsteroidOS, but several convenient functions are available when an AsteroidOS watch is paired with a *synchronization client*.
+ - Android users can use "AsteroidOSSync" which is available for [download on F-Droid](https://f-droid.org/packages/org.asteroidos.sync/)
+ - Ubuntu Touch users can download ["Telescope" from OpenStore](https://open-store.io/app/telescope.asteroidos)
+ - There is currently no app for iPhone, however notifications can be shared from an iPhone to the watch. See [this page]({{rel 'wiki/synchronization-clients'}}) for details.
+
 ## Is AsteroidOS based on Android?
 No. AsteroidOS uses [libhybris](https://en.wikipedia.org/wiki/Hybris_(software)) to simplify porting to most Android and WearOS watches, but it is not Android nor is it WearOS or a derivative of either.
 
@@ -59,9 +65,6 @@ Maybe in the future. See the [porting status]({{rel 'wiki/porting-status'}}) pag
 
 ## Will I be able to revert to the previous operating system after installing AsteroidOS on my watch?
 Yes, if you choose the "temporary install" option. See the [installation FAQ]({{rel 'install#FAQ'}}) for details.
-
-## Where can I find a phone synchronization app?
-A phone is not *required* to use AsteroidOS, but several convenient functions are available when an AsteroidOS watch is paired with a *synchronization client*. For Android phones, "AsteroidOSSync" is available for [download on F-Droid](https://f-droid.org/packages/org.asteroidos.sync/). Ubuntu Touch users can download ["Telescope" from OpenStore](https://open-store.io/app/telescope.asteroidos). There is currently no app for iPhone, however notifications can be shared from an iPhone to the watch. See [this page]({{rel 'wiki/synchronization-clients'}}) for details.
 
 ## What features and apps does AsteroidOS currently **not** provide?
 There are a great many more *ideas* for apps than apps at the moment. Some of the more commonly requested, but not yet available applications and features are:

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -66,7 +66,8 @@ The available AsteroidOS features depend on the watch you want to use. Review th
 Or check the [features table]({{rel 'install/features'}}) to see a matrix of all AsteroidOS watches and their feature support.
 
 ## My watch isn't listed. Can I still run AsteroidOS?
-Maybe in the future. See the [porting status]({{rel 'wiki/porting-status'}}) page for details on what kinds of watches might be supported in the future and what the general requirements are for running AsteroidOS.
+Maybe in the future. See the [porting status]({{rel 'wiki/porting-status'}}) page for details on what kinds of watches might be supported in the future and what the general requirements are for running AsteroidOS.\
+If you are interested in porting AsteroidOS to a new watch yourself, please read the [Porting Guide] ({{rel 'wiki/porting-guide'}}) page and contact us via our [matrix channel]({{rel 'contact'}}) in case of possible questions.
 
 ## Will I be able to revert to the previous operating system after installing AsteroidOS on my watch?
 Yes, very easily if you choose the "temporary install" option.\

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -36,6 +36,9 @@ The following apps are delivered with an AsteroidOS installation:
  - timer
  - weather forecast
 
+## Is there something like a "Play Store" to download apps?
+Not yet, but this is something that is being considered for future implementation. There are a number of contributed apps that are not installed in the default image. These can be [installed manually]({{rel 'wiki/package-installation/#packageinstallation'}}) if desired.
+
 ## Where can I find a phone synchronization app?
 A phone is not *required* to use AsteroidOS, but several convenient functions are available when an AsteroidOS watch is paired with a *synchronization client*.
  - Android users can use "AsteroidOSSync" which is available for [download on F-Droid](https://f-droid.org/packages/org.asteroidos.sync/)
@@ -77,9 +80,6 @@ There are a great many more *ideas* for apps than apps at the moment. Some of th
  - *and many more*
 
 Some of these are being worked on, and others are just ideas at this point. If you think you might like to contribute, see our [GitHub repository](https://github.com/AsteroidOS/asteroid/issues) and the [Contact]({{rel 'contact'}}) page. There are many opportunities for creativity!
-
-## Is there something like a "Play Store" to download apps?
-Not yet, but this is something that is being considered for future implementation. There are a number of contributed apps that are not installed in the default image. These can be [installed manually]({{rel 'wiki/package-installation/#packageinstallation'}}) if desired.
 
 ## What if my question isn't answered here?
 There are many additional resources. The [Documentation]({{rel 'documentation'}}) page should be your first stop. It has a lot of useful information about both using and developing for AsteroidOS. If you can't find your answer on this web site, see [Contact]({{rel 'contact'}}).

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -12,11 +12,11 @@ One of the main goals of AsteroidOS is to provide users with greater control ove
 
 ## Which features does AsteroidOS provide?
 Currently, AsteroidOS has these features available:
- - phone notifications
  - Always-on-Display
- - tilt to wake
- - palm to sleep
- - multiple launcher styles
+ - Tilt-to-Wake
+ - Palm-to-Sleep
+ - phone notifications
+ - multiple app launcher styles
  - wallpapers
  - [community watchfaces](https://github.com/AsteroidOS/unofficial-watchfaces)
  - nightstand mode

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -75,7 +75,7 @@ Review the [Building AsteroidOS]({{rel 'wiki/building-asteroidos'}}) page for de
 
 ## My watch isn't listed. Can I still run AsteroidOS?
 Maybe in the future. See the [porting status]({{rel 'wiki/porting-status'}}) page for details on what kinds of watches might be supported in the future and what the general requirements are for running AsteroidOS.\
-If you are interested in porting AsteroidOS to a new watch yourself, please read the [Porting Guide] ({{rel 'wiki/porting-guide'}}) page and contact us via our [matrix channel]({{rel 'contact'}}) in case of possible questions.
+If you are interested in porting AsteroidOS to a new watch yourself, please read the [Porting Guide]({{rel 'wiki/porting-guide'}}) page and contact us via our [matrix channel]({{rel 'contact'}}) in case of possible questions.
 
 ## Which features of my watch are currently supported by AsteroidOS?
 The available AsteroidOS features depend on the watch you want to use. Review the table on the installation page for your device to get detailed support information.\

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -7,7 +7,8 @@ layout: documentation
 
 This page contains some Frequently Asked Questions.
 ## What is AsteroidOS?
-AsteroidOS is an open source Linux distribution that runs on many different smartwatches. It uses [Qt](http://www.qt.io/) and QML to provide the graphical interface.
+AsteroidOS is an open source Linux distribution that runs on many different smartwatches. It uses [Qt](http://www.qt.io/) and QML to provide the graphical interface.\
+One of the main goals of AsteroidOS is to provide users with greater control over their devices and data privacy. The operating system is fully customizable, and users can modify it to meet their specific needs.
 
 ## Which features does AsteroidOS provide?
 Currently, AsteroidOS has these features available:

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -62,7 +62,8 @@ No. AsteroidOS does not collect any tracking data and you don't need to use or e
 Maybe. Check the [Install]({{rel 'install'}}) page to see if your watch is listed.
 
 ## Which features of my watch are currently supported by AsteroidOS?
-Check the [features table]({{rel 'install/features'}}) to see all of the watches and which features they support.
+The available AsteroidOS features depend on the watch you want to use. Review the table on the installation page for your device to get detailed support information.\
+Or check the [features table]({{rel 'install/features'}}) to see a matrix of all AsteroidOS watches and their feature support.
 
 ## My watch isn't listed. Can I still run AsteroidOS?
 Maybe in the future. See the [porting status]({{rel 'wiki/porting-status'}}) page for details on what kinds of watches might be supported in the future and what the general requirements are for running AsteroidOS.

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -4,8 +4,8 @@ slug: faq
 layout: documentation
 ---
 # FAQ
-
 This page contains some Frequently Asked Questions.
+
 ## What is AsteroidOS?
 AsteroidOS is an open source Linux distribution that runs on many different smartwatches. It uses [Qt](http://www.qt.io/) and QML to provide the graphical interface.\
 One of the main goals of AsteroidOS is to provide users with greater control over their devices and data privacy. The operating system is fully customizable, and users can modify it to meet their specific needs.
@@ -45,6 +45,15 @@ A phone is not *required* to use AsteroidOS, but several convenient functions ar
  - Ubuntu Touch users can download ["Telescope" from OpenStore](https://open-store.io/app/telescope.asteroidos)
  - There is currently no app for iPhone, however notifications can be shared from an iPhone to the watch. See [this page]({{rel 'wiki/synchronization-clients'}}) for details.
 
+## What features and apps does AsteroidOS currently **not** provide?
+There are a great many more *ideas* for apps than apps at the moment. Some of the more commonly requested, but not yet available applications and features are:
+ - Call answering from the watch
+ - Fitness and health tracking application (step counter, ongoing heartrate monitor, etc.)
+ - Support for using the watch as a phone (for some watches that incorporate a cellular phone chip)
+ - *And many more*
+
+Some of these are being worked on, and others are just ideas at this point. If you think you might like to contribute, see our [GitHub repository](https://github.com/AsteroidOS/asteroid/issues) and the [Contact]({{rel 'contact'}}) page. There are many opportunities for creativity!
+
 ## Is AsteroidOS based on Android?
 No. AsteroidOS uses [libhybris](https://en.wikipedia.org/wiki/Hybris_(software)) to simplify porting to most Android and WearOS watches, but it is not Android nor is it WearOS or a derivative of either.
 
@@ -61,30 +70,21 @@ No. AsteroidOS does not collect any tracking data and you don't need to use or e
 ## Can I run AsteroidOS on my watch?
 Maybe. Check the [Install]({{rel 'install'}}) page to see if your watch is listed.
 
-## Which features of my watch are currently supported by AsteroidOS?
-The available AsteroidOS features depend on the watch you want to use. Review the table on the installation page for your device to get detailed support information.\
-Or check the [features table]({{rel 'install/features'}}) to see a matrix of all AsteroidOS watches and their feature support.
+## I do not want to flash a prebuilt image on my watch. Can I compile AsteroidOS myself?
+Review the [Building AsteroidOS]({{rel 'wiki/building-asteroidos'}}) page for detailed instructions on how to compile AsteroidOS yourself.
 
 ## My watch isn't listed. Can I still run AsteroidOS?
 Maybe in the future. See the [porting status]({{rel 'wiki/porting-status'}}) page for details on what kinds of watches might be supported in the future and what the general requirements are for running AsteroidOS.\
 If you are interested in porting AsteroidOS to a new watch yourself, please read the [Porting Guide] ({{rel 'wiki/porting-guide'}}) page and contact us via our [matrix channel]({{rel 'contact'}}) in case of possible questions.
 
-## I do not want to flash a prebuilt image on my watch. Can I compile AsteroidOS myself?
-Review the [Building AsteroidOS]({{rel 'wiki/building-asteroidos'}}) page for detailed instructions on how to compile AsteroidOS yourself.
+## Which features of my watch are currently supported by AsteroidOS?
+The available AsteroidOS features depend on the watch you want to use. Review the table on the installation page for your device to get detailed support information.\
+Or check the [features table]({{rel 'install/features'}}) to see a matrix of all AsteroidOS watches and their feature support.
 
 ## Will I be able to revert to the previous operating system after installing AsteroidOS on my watch?
 Yes, very easily if you choose the "temporary install" option.\
 For most watches, you may choose to only temporarily install AsteroidOS alongside the existing OS, called a "dual-boot". When doing so, the `asteroidos.ext4` image is pushed to the userdata partition using ADB. With no alteration to the previous OS. The downside of this method being, AsteroidOS needs to be manually booted using `fastboot boot boot-image.fastboot` while connected via USB, after every reboot or shutdown. Else, the previous OS will start up as usual.\
 In case you decide to replace your previous OS using the full install method, to make the watch boot into AsteroidOS without manual intervention. It is advised that you make a backup of your <b>userdata</b> and <b>boot</b> partitions before flashing AsteroidOS. Only then, you will be able to re-flash those backups to restore the previous OS later.
-
-## What features and apps does AsteroidOS currently **not** provide?
-There are a great many more *ideas* for apps than apps at the moment. Some of the more commonly requested, but not yet available applications and features are:
- - Call answering from the watch
- - Fitness and health tracking application (step counter, ongoing heartrate monitor, etc.)
- - Support for using the watch as a phone (for some watches that incorporate a cellular phone chip)
- - *And many more*
-
-Some of these are being worked on, and others are just ideas at this point. If you think you might like to contribute, see our [GitHub repository](https://github.com/AsteroidOS/asteroid/issues) and the [Contact]({{rel 'contact'}}) page. There are many opportunities for creativity!
 
 ## What if my question isn't answered here?
 There are many additional resources. The [Documentation]({{rel 'documentation'}}) page should be your first stop. It has a lot of useful information about both using and developing for AsteroidOS. If you can't find your answer on this web site, see [Contact]({{rel 'contact'}}).

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -72,10 +72,8 @@ Yes, if you choose the "temporary install" option. See the [installation FAQ]({{
 
 ## What features and apps does AsteroidOS currently **not** provide?
 There are a great many more *ideas* for apps than apps at the moment. Some of the more commonly requested, but not yet available applications and features are:
- - fitness tracking application
- - step counter
- - ongoing heartrate monitor
  - call answering from the watch
+ - fitness and health tracking application (step counter, ongoing heartrate monitor, etc.)
  - support for using the watch as a phone (for some watches that incorporate a cellular phone chip)
  - *and many more*
 

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -68,7 +68,9 @@ Check the [features table]({{rel 'install/features'}}) to see all of the watches
 Maybe in the future. See the [porting status]({{rel 'wiki/porting-status'}}) page for details on what kinds of watches might be supported in the future and what the general requirements are for running AsteroidOS.
 
 ## Will I be able to revert to the previous operating system after installing AsteroidOS on my watch?
-Yes, if you choose the "temporary install" option. See the [installation FAQ]({{rel 'install#FAQ'}}) for details.
+Yes, very easily if you choose the "temporary install" option.\
+For most watches, you may choose to only temporarily install AsteroidOS alongside the existing OS, called a "dual-boot". When doing so, the `asteroidos.ext4` image is pushed to the userdata partition using ADB. With no alteration to the previous OS. The downside of this method being, AsteroidOS needs to be manually booted using `fastboot boot boot-image.fastboot` while connected via USB, after every reboot or shutdown. Else, the previous OS will start up as usual.\
+In case you decide to replace your previous OS using the full install method, to make the watch boot into AsteroidOS without manual intervention. It is advised that you make a backup of your <b>userdata</b> and <b>boot</b> partitions before flashing AsteroidOS. Only then, you will be able to re-flash those backups to restore the previous OS later.
 
 ## What features and apps does AsteroidOS currently **not** provide?
 There are a great many more *ideas* for apps than apps at the moment. Some of the more commonly requested, but not yet available applications and features are:

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -13,24 +13,24 @@ One of the main goals of AsteroidOS is to provide users with greater control ove
 ## Which features does AsteroidOS provide?
 Currently, AsteroidOS has these features available:
  - phone notifications
- - always on display
+ - Always-on-Display
  - tilt to wake
  - palm to sleep
  - multiple launcher styles
- - (live) wallpapers
+ - wallpapers
  - [community watchfaces](https://github.com/AsteroidOS/unofficial-watchfaces)
  - nightstand mode
 
 ## Does AsteroidOS have any apps included?
 The following apps are delivered with an AsteroidOS installation:
- - agenda, a calender
+ - agenda, a calendar
  - alarm clock
  - calculator
  - compass
  - diamonds game
  - flashlight
  - heartrate check
- - music, a MPRIS media remote control
+ - music, a media remote control
  - settings
  - stopwatch
  - timer

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -9,6 +9,32 @@ This page contains some Frequently Asked Questions.
 ## What is AsteroidOS?
 AsteroidOS is an open source Linux distribution that runs on many different smartwatches. It uses [Qt](http://www.qt.io/) and QML to provide the graphical interface.
 
+## Which features does AsteroidOS provide?
+Currently, AsteroidOS has these features available:
+ - phone notifications
+ - always on display
+ - tilt to wake
+ - palm to sleep
+ - multiple launcher styles
+ - (live) wallpapers
+ - [community watchfaces](https://github.com/AsteroidOS/unofficial-watchfaces)
+ - nightstand mode
+
+## Does AsteroidOS have any apps included?
+The following apps are delivered with an AsteroidOS installation:
+ - agenda, a calender
+ - alarm clock
+ - calculator
+ - compass
+ - diamonds game
+ - flashlight
+ - heartrate check
+ - music, a MPRIS media remote control
+ - settings
+ - stopwatch
+ - timer
+ - weather forecast
+
 ## Is AsteroidOS based on Android?
 No. AsteroidOS uses [libhybris](https://en.wikipedia.org/wiki/Hybris_(software)) to simplify porting to most Android and WearOS watches, but it is not Android nor is it WearOS or a derivative of either.
 
@@ -35,9 +61,6 @@ Yes, if you choose the "temporary install" option. See the [installation FAQ]({{
 
 ## Where can I find a phone synchronization app?
 A phone is not *required* to use AsteroidOS, but several convenient functions are available when an AsteroidOS watch is paired with a *synchronization client*. For Android phones, "AsteroidOSSync" is available for [download on F-Droid](https://f-droid.org/packages/org.asteroidos.sync/). Ubuntu Touch users can download ["Telescope" from OpenStore](https://open-store.io/app/telescope.asteroidos). There is currently no app for iPhone, however notifications can be shared from an iPhone to the watch. See [this page]({{rel 'wiki/synchronization-clients'}}) for details.
-
-## What features and apps does AsteroidOS provide?
-Since version 1.0, AsteroidOS has had phone notifications, an agenda, an alarm clock, a calculator, a music remote control, settings customizations, a stopwatch, a timer, and a weather forecast app. Since then, we have also added a game, a flashlight app, a heartrate checking app and many more watchfaces.
 
 ## What features and apps does AsteroidOS currently **not** provide?
 There are a great many more *ideas* for apps than apps at the moment. Some of the more commonly requested, but not yet available applications and features are:

--- a/pages/main/faq.md
+++ b/pages/main/faq.md
@@ -42,7 +42,8 @@ No. AsteroidOS uses [libhybris](https://en.wikipedia.org/wiki/Hybris_(software))
 No. [WearOS](https://en.wikipedia.org/wiki/Wear_OS) is a version of Android that runs on wearable devices. AsteroidOS is a Linux distribution that does not run Android and therefore cannot run either Android or WearOS applications.
 
 ## What are the differences between AsteroidOS and WearOS?
-One significant difference is that AsteroidOS is open source software, while WearOS is not. This means that if you would like to change something, and you are a developer, you can [build the software]({{rel 'wiki/building-asteroidos'}}) yourself. Or perhaps you would like to [create your own watchface]({{rel 'wiki/watchfaces-creation'}}). Another significant difference is that unlike WearOS, AsteroidOS tries to make the watch useful even without pairing it with a phone. By contrast, WearOS watches won't even start running until they are paired with a phone.
+One significant difference is that AsteroidOS is open source software, while WearOS is not. That is, if you want to change something and you are a developer, you can [build the software]({{rel 'wiki/building-asteroidos'}}) yourself. Or perhaps you would like to [create your own watchface]({{rel 'wiki/watchfaces-creation'}}).\
+Another significant difference is that AsteroidOS, unlike WearOS, tries to make the watch usable without pairing it with a phone. In contrast, WearOS watches only run when they are paired with a phone.
 
 ## Does AsteroidOS have any tracking features?
 No. AsteroidOS does not collect any tracking data and you don't need to use or establish any accounts to use it. Nothing on the default installation is able to connect to the internet. While it is possible to [connect an AsteroidOS watch to the internet]({{rel 'wiki/ip-connection'}}) this must be explicitly done by the user.


### PR DESCRIPTION
The FAQ section is now linked from the start page using the "Learn more" button.
Imo, thus the faq sections purpose has shifted from trying to firstly clear up misconceptions (and fence off buggy questions), to advertise our work and explain new users what they can expect.
To achive this:
- Move the apps and features section up and reformulated them into lists and added missing features.
- Move the "Playstore question" section right below the actual included apps section
- Move the sync client section up, above the "Differences to android" tirade.
- Add a user centric explanatory sentence to first section
- Streamline differences to wearos text.

Visually:
![grafik](https://user-images.githubusercontent.com/15074193/219899123-3611fcdb-1e41-4549-b04f-fd63495c7cd9.png)
![grafik](https://user-images.githubusercontent.com/15074193/219899153-a6e6d6ac-3f21-4bdb-90c0-c869e00eaeda.png)
