### PR TITLE
Adapt install page text to recent move of the install FAQ

### DIFF
--- a/templates/layouts/aw-install-multi.hbs
+++ b/templates/layouts/aw-install-multi.hbs
@@ -13,7 +13,7 @@
     <div class="container docs-container">
       <h1>Hardware Support</h1>
       {{#deviceNames}}
-        The following table summarizes the current support of the <b>{{.}}</b> version of this watch:
+        The following table summarizes the state of the features of the <b>{{.}}</b> version of this watch:
         <table>
         {{#with (getModel .)}}
           <tr>

--- a/templates/layouts/aw-install-multi.hbs
+++ b/templates/layouts/aw-install-multi.hbs
@@ -12,8 +12,6 @@
     {{!-- Content --}}
     <div class="container docs-container">
       <h1>Hardware Support</h1>
-      <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}.</p>
-
       {{#deviceNames}}
         The following table summarizes the current support of the <b>{{.}}</b> version of this watch:
         <table>

--- a/templates/layouts/aw-install-simg.hbs
+++ b/templates/layouts/aw-install-simg.hbs
@@ -12,7 +12,7 @@
     {{!-- Content --}}
     <div class="container docs-container">
       <h1>Hardware Support</h1>
-      <p>The following table is a summary of the currently supported features of the {{title}}.</p>
+      <p>The following table summarizes the state of the features of the {{title}}.</p>
       <table>
       {{#with (getModel deviceName)}}
         <tr> 

--- a/templates/layouts/aw-install-simg.hbs
+++ b/templates/layouts/aw-install-simg.hbs
@@ -12,7 +12,7 @@
     {{!-- Content --}}
     <div class="container docs-container">
       <h1>Hardware Support</h1>
-      <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}. The following table should summarize the current support of this watch:</p>
+      <p>The following table is a summary of the currently supported features of the {{title}}.</p>
       <table>
       {{#with (getModel deviceName)}}
         <tr> 

--- a/templates/layouts/aw-install.hbs
+++ b/templates/layouts/aw-install.hbs
@@ -12,7 +12,7 @@
     {{!-- Content --}}
     <div class="container docs-container">
       <h1>Hardware Support</h1>
-      <p>The following table is a summary of the currently supported features of the {{title}}.</p>
+      <p>The following table summarizes the state of the features of the {{title}}.</p>
       <table>
       {{#with (getModel deviceName)}}
         <tr> 

--- a/templates/layouts/aw-install.hbs
+++ b/templates/layouts/aw-install.hbs
@@ -12,7 +12,7 @@
     {{!-- Content --}}
     <div class="container docs-container">
       <h1>Hardware Support</h1>
-      <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}. The following table should summarize the current support of this watch:</p>
+      <p>The following table is a summary of the currently supported features of the {{title}}.</p>
       <table>
       {{#with (getModel deviceName)}}
         <tr> 

--- a/templates/layouts/beluga-install.hbs
+++ b/templates/layouts/beluga-install.hbs
@@ -12,7 +12,7 @@
     {{!-- Content --}}
     <div class="container docs-container">
       <h1>Hardware Support</h1>
-      <p>The following table is a summary of the currently supported features of the {{title}}.</p>
+      <p>The following table summarizes the state of the features of the {{title}}.</p>
       <table>
       {{#with (getModel deviceName)}}
         <tr> 

--- a/templates/layouts/beluga-install.hbs
+++ b/templates/layouts/beluga-install.hbs
@@ -12,7 +12,7 @@
     {{!-- Content --}}
     <div class="container docs-container">
       <h1>Hardware Support</h1>
-      <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}. The following table should summarize the current support of this watch:</p>
+      <p>The following table is a summary of the currently supported features of the {{title}}.</p>
       <table>
       {{#with (getModel deviceName)}}
         <tr> 

--- a/templates/layouts/main-install.hbs
+++ b/templates/layouts/main-install.hbs
@@ -17,7 +17,7 @@
     <div class="container docs-container">
       <p>AsteroidOS can be installed as an alternative operating system on various smartwatches. Instructions for each model can be found below.</p>
       <p>Before installing AsteroidOS, make sure you are aware of the capabilities and limitations of AsteroidOS by consulting the <a href="{{rel 'faq'}}">FAQ page</a>.</p>
-      <p>In case you want to compare supported features of all watches AsteroidOS supports, have a look at the <a href="{{rel 'install/features'}}">Features Table</a>.</p>
+      <p>A summary of the state of all features of all watches AsteroidOS supports is in the <a href="{{rel 'install/features'}}">Features Table</a>.</p>
     {{#each (getAllWithStatus "supported")}}
       {{> installbox}}
     {{/each}}

--- a/templates/layouts/main-install.hbs
+++ b/templates/layouts/main-install.hbs
@@ -15,9 +15,9 @@
 
     {{!-- Content --}}
     <div class="container docs-container">
-      <p>Supported features of all watches are in the <a href="{{rel 'install/features'}}">Features Table</a></p>
-      <p>AsteroidOS can be installed as an alternative operating system on various smartwatches. Instructions for each model can be found below:</p>
-      <p>If you have questions regarding the installation process, please check out the <a href="#FAQ">Install FAQ</a> section.</p>
+      <p>AsteroidOS can be installed as an alternative operating system on various smartwatches. Instructions for each model can be found below.</p>
+      <p>Before installing AsteroidOS, make sure you are aware of the capabilities and limitations of AsteroidOS by consulting the <a href="{{rel 'faq'}}">FAQ page</a>.</p>
+      <p>In case you want to compare supported features of all watches AsteroidOS supports, have a look at the <a href="{{rel 'install/features'}}">Features Table</a>.</p>
     {{#each (getAllWithStatus "supported")}}
       {{> installbox}}
     {{/each}}

--- a/templates/layouts/mooneye-install.hbs
+++ b/templates/layouts/mooneye-install.hbs
@@ -12,7 +12,7 @@
     {{!-- Content --}}
     <div class="container docs-container">
       <h1>Hardware Support</h1>
-      <p>The following table is a summary of the currently supported features of the {{title}}.</p>
+      <p>The following table summarizes the state of the features of the {{title}}.</p>
       <table>
       {{#with (getModel deviceName)}}
         <tr> 

--- a/templates/layouts/mooneye-install.hbs
+++ b/templates/layouts/mooneye-install.hbs
@@ -12,7 +12,7 @@
     {{!-- Content --}}
     <div class="container docs-container">
       <h1>Hardware Support</h1>
-      <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}. The following table should summarize the current support of this watch:</p>
+      <p>The following table is a summary of the currently supported features of the {{title}}.</p>
       <table>
       {{#with (getModel deviceName)}}
         <tr> 

--- a/templates/layouts/mtk-install.hbs
+++ b/templates/layouts/mtk-install.hbs
@@ -12,7 +12,7 @@
     {{!-- Content --}}
     <div class="container docs-container">
       <h1>Hardware Support</h1>
-      <p>The following table is a summary of the currently supported features of the {{title}}.</p>
+      <p>The following table summarizes the state of the features of the {{title}}.</p>
       <table>
       {{#with (getModel deviceName)}}
         <tr> 

--- a/templates/layouts/mtk-install.hbs
+++ b/templates/layouts/mtk-install.hbs
@@ -12,7 +12,7 @@
     {{!-- Content --}}
     <div class="container docs-container">
       <h1>Hardware Support</h1>
-      <p>Before installing AsteroidOS to your watch, make sure you are aware of the capabilities and limitations of AsteroidOS on the {{title}}. The following table should summarize the current support of this watch:</p>
+      <p>The following table is a summary of the currently supported features of the {{title}}.</p>
       <table>
       {{#with (getModel deviceName)}}
         <tr> 


### PR DESCRIPTION
The main install page now asks to make sure to be familiar with the FAQ before installing. 
Making the individual sentences on each install page redundant. 