### PR TITLE
Add note about generic iOS BLE apps

### DIFF
--- a/pages/wiki/synchronization-clients.md
+++ b/pages/wiki/synchronization-clients.md
@@ -24,7 +24,7 @@ layout: documentation
 
 <p>There is currently no application available for iOS phones to synchronize with AsteroidOS watches. As far as we know, there hasn't been any development done on such an app yet.</p>
 
-<p>One can however use generic BLE scanners/communication apps like <a href="https://apps.apple.com/gb/app/nrf-connect-for-mobile/id1054362403">nRF Connect</a> to still connect the watch to an iOS device and even use it to send notifications to the watch. Specific functionality like syncing time or weather forecast are however not supported!</p>
+<p>However, if the watch is paired with an iOS device, AsteroidOS is capable of displaying notifications from the phone. Pairing can be done using Apple's Bluetooth settings, but several iOS users have reported that a generic BLE scanner/communication app like <a href="https://apps.apple.com/gb/app/nrf-connect-for-mobile/id1054362403">nRF Connect</a> seems to be more reliable for pairing Bluetooth devices. Specific functionality like syncing time or weather forecast are however not supported!</p>
 
 <div class="page-header">
   <h1 id="sfos">SailfishOS application</h1>

--- a/pages/wiki/synchronization-clients.md
+++ b/pages/wiki/synchronization-clients.md
@@ -24,6 +24,8 @@ layout: documentation
 
 <p>There is currently no application available for iOS phones to synchronize with AsteroidOS watches. As far as we know, there hasn't been any development done on such an app yet.</p>
 
+<p>One can however use generic BLE scanners/communication apps like <a href="https://apps.apple.com/gb/app/nrf-connect-for-mobile/id1054362403">nRF Connect</a> to still connect the watch to an iOS device and even use it to send notifications to the watch. Specific functionality like syncing time or weather forecast are however not supported!</p>
+
 <div class="page-header">
   <h1 id="sfos">SailfishOS application</h1>
 </div>


### PR DESCRIPTION
In particular how they can be used to connect a watch running AsteroidOS to an iOS device.

I came across [nRF Connect](https://apps.apple.com/gb/app/nrf-connect-for-mobile/id1054362403) while checking the [PineTime wiki](https://wiki.pine64.org/wiki/PineTime_FAQ#How_do_I_set_the_time_on_PineTime?) and found it also works with my lenok running AsteroidOS. I don't have other watches so I cannot confirm whether it works on all devices running AsteroidOS.

This is also by no means a replacement for a proper sync client but certainly better than no sync at all :P

(Now if someone could just fork [InfiniLink](https://github.com/InfiniTimeOrg/InfiniLink) and adapt it for AsteroidOS so that we have a proper sync client on iOS, that would be great x_x)