### PR TITLE
Rename firefish and ray to Fossil Gen 4 46mm and 41mm

### DIFF
--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -156,7 +156,7 @@
     {
       "name":"firefish",
       "models": [
-        "Fossil Gen 4"
+        "Fossil Gen 4 46mm"
       ],
       "modelnumbers": [
         { "num":"DW6A1", "name":"Armani Exchange Connected Drexler", "codename":"firefish" },
@@ -388,7 +388,7 @@
       "name":"ray",
       "reference": "firefish",
       "models": [
-        "Skagen Falster 2"
+        "Fossil Gen 4 41mm"
       ],
       "modelnumbers": [
       ],


### PR DESCRIPTION
Due to recent addition of many more firefish and ray models, the skagen falster 2 name for ray became unfitting.
Renaming to the main differentiationg factor, the casing size.

![image](https://user-images.githubusercontent.com/15074193/221380192-6bba94a2-c8a1-4a1b-ad41-3047430d64f5.png)
