### PR TITLE
Add crown to feature matrix and feature table of supported watches

### DIFF
--- a/pages/all-features-template.json
+++ b/pages/all-features-template.json
@@ -34,6 +34,7 @@
         { "name":"NFC", "status":"bad" },                                       // not yet implemented anywhere
         { "name":"Cellular", "status":"bad" },                                  // not yet implemented anywhere
         { "name":"Camera", "status":"good/partial/bad/unknown" },
+        { "name":"Crown", "status":"good/partial/bad/unknown" },
         { "name":"Hands", "status":"bad" },
       ]
     },

--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -194,7 +194,8 @@
         { "name":"USB", "status":"good" },
         { "name":"WLAN", "status":"good" },
         { "name":"GPS", "status":"bad" },
-        { "name":"NFC", "status":"bad" }
+        { "name":"NFC", "status":"bad" },
+        { "name":"Crown", "status":"good" }
       ]
     },
     {
@@ -381,6 +382,7 @@
         { "name":"Compass", "status":"good" },
         { "name":"USB", "status":"good" },
         { "name":"WLAN", "status":"bad" },
+        { "name":"Crown", "status":"good" },
         { "name":"Hands", "status":"bad" }
       ]
     },
@@ -411,7 +413,8 @@
         { "name":"USB", "status":"good" },
         { "name":"WLAN", "status":"good" },
         { "name":"GPS", "status":"bad" },
-        { "name":"NFC", "status":"bad" }
+        { "name":"NFC", "status":"bad" },
+        { "name":"Crown", "status":"good" }
       ]
     },
     {


### PR DESCRIPTION
As brought up by @docgalaxyblock and discussed with @MagneFire 
This PR adds "Crown" as a feature to watches that got the hardware to make the feature more easily discoverable and document it properly.

![image](https://user-images.githubusercontent.com/15074193/221400422-4647b5f1-dfbe-4a40-983a-ae21946be5cd.png)

![image](https://user-images.githubusercontent.com/15074193/221400451-869416c3-4347-4c0a-ba4b-3db8871d4d2d.png)

![image](https://user-images.githubusercontent.com/15074193/221400465-dfb02bf7-9dc7-428e-9384-d7e7b45cf675.png)
