### PR TITLE
Remove pike from unreleased section

### DIFF
--- a/pages/wiki/porting-status.md
+++ b/pages/wiki/porting-status.md
@@ -36,7 +36,6 @@ The WearOS smartwatches are the most widespread and easy to support. The source 
 - [Casio WSD-FXX Series (ayu/koi)](https://github.com/AsteroidOS/meta-smartwatch/pull/140) maintained by dodoradio
 - [Fossil Gen5 (triggerfish)](https://github.com/AsteroidOS/meta-smartwatch/pull/138) maintained by dodoradio
 - [LG Watch Urbane 2nd Edition (nemo)](https://github.com/AsteroidOS/meta-smartwatch/pull/153) maintained by eLtMosen
-- [Polar M600 (pike)](https://github.com/AsteroidOS/meta-smartwatch/pull/139) maintained by dodoradio
 
 &nbsp;
 ### Possible ports not yet supported


### PR DESCRIPTION
Due to addition of pike to the supported watches, this removes it from the unreleased section on the porting status page.