### PR TITLE
Make features table responsive

### DIFF
--- a/styles/components/install-support-table.less
+++ b/styles/components/install-support-table.less
@@ -7,11 +7,11 @@
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  flex-wrap: wrap;
+  max-width: 1024px;
 }
 
 th.rotated {
-    width: 30px;
+    width: 3.5VW;
     height: 40px;
     white-space: nowrap;
     transform: translateX(10px) rotate(-45deg);
@@ -33,9 +33,12 @@ th.rotated {
 }
 
 td.support-col {
-  min-width: 25px;
+  min-width: 15px;
 }
 
+th {
+  min-width: 17px;
+}
 .name-col {
     width: 90px;
 }

--- a/templates/includes/install-header.hbs
+++ b/templates/includes/install-header.hbs
@@ -5,6 +5,6 @@
 <g transform="translate(-73.598 -103.17)">
 <g transform="translate(1.6)" fill="#666">
 <path d="m73.598 103.17h0.85725l2.8998 4.8154-2.8998 4.8154h-0.85725l2.8892-4.8154z" fill="#666" stroke-width=".26458"/>
-</g></g></svg> {{ title }} ({{#if label}}{{label}}{{else}}{{deviceName}}{{/if}})</h1>
+</g></g></svg> {{ title }} {{#if deviceName}}({{deviceName}}){{else if label}}({{label}}){{/if}}</h1>
   </div>
 </div>


### PR DESCRIPTION
The features table did wrap unfortunate on mobile devices.
This PR
- Makes the support-column width depend on viewport width
- Limits the minimum columns size to 15px where it was 25px before
- Removes the support-row wrap, introducing horizontal scroll on width lower than 600px.
- Sets a max-width of 1024px for the support-row so it does not get wider than the top menu

Downsides 
- The columns are rectangles, not squares anymore.
- This is hardcoded to 3.5VW and needs to be lowered in case more columns get added

Before, reported by @thorgalix21 on matrix:
![grafik](https://user-images.githubusercontent.com/15074193/222313550-4c3d1d48-a5d1-49f4-bfa7-7273d2016d30.png)

Behaviour with PR implemented:

https://user-images.githubusercontent.com/15074193/222314645-da10b5e6-f40d-431d-8ced-265b75f08f79.mp4

