### PR TITLE
Redesign install main page colums

### DIFF
--- a/styles/components/install-box.less
+++ b/styles/components/install-box.less
@@ -15,21 +15,47 @@
   border-radius: 4px;
 
   display: inline-block;
-  width: 100%;
+  width: 184px;
+  margin-left: 15VW;
+  margin-top: 20px;
 
   text-align: center;
 
   .box-shadow(0 2px 4px rgba(0,0,0,.2));
 
-  @media (min-width: @grid-float-breakpoint) {
-    width: 45%;
-    margin: 2%
+  @media (min-width: 340px) {
+    width: 60%;
+    margin-left: 17VW;
+    margin-top: 20px;
+  }
+
+  @media (min-width: @screen-xs-min) {
+    width: 41%;
+    margin: 3%
+  }
+
+  @media (min-width: @screen-sm-min) {
+    width: 31.2%;
+    margin: 0.9%
   }
 
   @media (min-width: @screen-md-min) {
-    width: 20%;
-    margin: 2%
+    width: 23.3%;
+    margin: 0.7%
   }
+
+  @media (min-width: @screen-lg-min) {
+    width: 18.7%;
+    margin: 0.5%
+  }
+}
+
+.install-watch-img {
+  width: 100%;
+  max-width: 300px;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
 }
 
 // Android Wear screenshots in an install page

--- a/templates/includes/installbox.hbs
+++ b/templates/includes/installbox.hbs
@@ -1,6 +1,6 @@
 {{#with this}}
   <a href="{{#if reference}}{{reference}}{{else}}{{name}}{{/if}}"><div class="install-box">
-    <img src="../public/img/{{name}}.png" width="100%"><br>
+    <img src="../public/img/{{name}}.png" class="install-watch-img"><br>
     <b>{{models}}</b><br>({{name}}{{#if othernames}},{{othernames}}{{/if}})<br>
     <i>Support: {{#starString stars 5}}{{/starString}}</i>
   </div></a>


### PR DESCRIPTION
- Main goal is to fix the huge watch images when the page is viewed on phones.
- Now we got 
5 columns on wider than 1200px screens
4 columns at wider than 992px
3 columns up to 768px
2 columns from 480px
1 column below 480px, that one only at 60% width so the image is not blown up like before
- The table is now centered better than before, best to observe when focusing on the right edge alignment to the outer most menu item "contact". 

Before:

https://user-images.githubusercontent.com/15074193/222521340-b557b103-5403-4d09-b981-e7152af885a6.mp4

After

https://user-images.githubusercontent.com/15074193/222521389-c2d9fe33-664b-494f-965c-d3d1316222fc.mp4

View on a typical modern phone according to chromium:

https://user-images.githubusercontent.com/15074193/222521537-bfb13f1b-ef5d-4196-85bf-a7a47f483333.mp4

