### PR TITLE
Fix news-img item to not occupy space when hidden

### DIFF
--- a/styles/components/news.less
+++ b/styles/components/news.less
@@ -46,9 +46,7 @@
   float: right;
 
   @media (max-width: @screen-md) {
-    visibility: hidden;
-    width: 0px;
-    height: 0px;
+    display: none;
   }
 }
 

--- a/templates/layouts/news.hbs
+++ b/templates/layouts/news.hbs
@@ -15,7 +15,7 @@
         <img src="/public/img/news-thumbnails/{{ thumbnails }}.jpg" width="100%" />
         <br><br><br>
       </div>
-      
+
       {{> body }}
 
       <hr>


### PR DESCRIPTION
This caused the nav-bar to be wider than the viewport

Before, toggling visibility: hidden and width
https://user-images.githubusercontent.com/15074193/222557284-d920e6fe-63d8-4f52-a80c-d428e80ac9d7.mp4

After setting display: none to the image
![grafik](https://user-images.githubusercontent.com/15074193/222557546-809319ee-1ecd-4c73-860e-b0efed103986.png)
