### PR TITLE
Change odd/even highlight to a more AsteroidOSish orange

### DIFF
--- a/styles/variables.less
+++ b/styles/variables.less
@@ -104,7 +104,7 @@
 @table-condensed-cell-padding:       5px;
 
 @table-bg:                           transparent; // overall background-color
-@table-bg-accent:                    #bce8f1; // for striping
+@table-bg-accent:                    #fff3d9; // for striping
 @table-bg-hover:                     #f5f5f5;
 @table-bg-active:                    @table-bg-hover;
 


### PR DESCRIPTION
Before
![grafik](https://user-images.githubusercontent.com/15074193/222600758-e49f442d-e3ef-44b5-aaf3-9da8b2edb63f.png)

After
![grafik](https://user-images.githubusercontent.com/15074193/222600840-796350b4-c8f2-42f4-88d3-803be0545940.png)
