### PR TITLE
Remove Clockwork mod USB driver and add Google USB driver

### DIFF
--- a/templates/layouts/aw-install-dual.hbs
+++ b/templates/layouts/aw-install-dual.hbs
@@ -61,9 +61,9 @@
         <br><br>
         <pre><code class="bash">sudo apt install android-tools-adb android-tools-fastboot</code></pre>
         <br>
-        <b>On Windows systems</b> install this ADB driver
+        <b>On Windows systems</b> install the Google USB driver
         <br><br>
-        <a class="btn btn-primary" href="{{#if windowsDrivers}}{{windowsDrivers}}{{else}}http://download.clockworkmod.com/test/UniversalAdbDriverSetup.msi{{/if}}" role="button">{{#if windowsDrivers}}{{replace windowsDrivers ".*\/" "" ""}}{{else}}UniversalAdbDriverSetup.msi{{/if}}</a>
+        <a class="btn btn-primary" href="https://developer.android.com/studio/run/win-usb" role="button" target="_blank" rel="noopener noreferrer" title="Open download source in new tab or window">Get the Google USB Driver ZIP</a>
         <br><br>
         Download this zip file containing ADB & Fastboot from Android SDK
         <br><br>

--- a/templates/layouts/aw-install-multi.hbs
+++ b/templates/layouts/aw-install-multi.hbs
@@ -62,9 +62,9 @@
         <br><br>
         <pre><code class="bash">sudo apt install android-tools-adb android-tools-fastboot</code></pre>
         <br>
-        <b>On Windows systems</b> install this ADB driver
+        <b>On Windows systems</b> install the Google USB driver
         <br><br>
-        <a class="btn btn-primary" href="{{#if windowsDrivers}}{{windowsDrivers}}{{else}}http://download.clockworkmod.com/test/UniversalAdbDriverSetup.msi{{/if}}" role="button">{{#if windowsDrivers}}{{replace windowsDrivers ".*\/" "" ""}}{{else}}UniversalAdbDriverSetup.msi{{/if}}</a>
+        <a class="btn btn-primary" href="https://developer.android.com/studio/run/win-usb" role="button" target="_blank" rel="noopener noreferrer" title="Open download source in new tab or window">Get the Google USB Driver ZIP</a>
         <br><br>
         Download this zip file containing ADB & Fastboot from Android SDK
         <br><br>

--- a/templates/layouts/aw-install-simg.hbs
+++ b/templates/layouts/aw-install-simg.hbs
@@ -55,9 +55,9 @@
         <br><br>
         <pre><code class="bash">sudo apt install android-tools-adb android-tools-fastboot android-tools-fsutils</code></pre>
         <br>
-        <b>On Windows systems</b> install this ADB driver
+        <b>On Windows systems</b> install the Google USB driver
         <br><br>
-        <a class="btn btn-primary" href="{{#if windowsDrivers}}{{windowsDrivers}}{{else}}http://download.clockworkmod.com/test/UniversalAdbDriverSetup.msi{{/if}}" role="button">{{#if windowsDrivers}}{{replace windowsDrivers ".*\/" "" ""}}{{else}}UniversalAdbDriverSetup.msi{{/if}}</a>
+        <a class="btn btn-primary" href="https://developer.android.com/studio/run/win-usb" role="button" target="_blank" rel="noopener noreferrer" title="Open download source in new tab or window">Get the Google USB Driver ZIP</a>
         <br><br>
         Download this zip file containing ADB & Fastboot from Android SDK
         <br><br>

--- a/templates/layouts/aw-install.hbs
+++ b/templates/layouts/aw-install.hbs
@@ -54,9 +54,9 @@
         <br><br>
         <pre><code class="bash">sudo apt install android-tools-adb android-tools-fastboot</code></pre>
         <br>
-        <b>On Windows systems</b> install this ADB driver
+        <b>On Windows systems</b> install the Google USB driver
         <br><br>
-        <a class="btn btn-primary" href="{{#if windowsDrivers}}{{windowsDrivers}}{{else}}http://download.clockworkmod.com/test/UniversalAdbDriverSetup.msi{{/if}}" role="button">{{#if windowsDrivers}}{{replace windowsDrivers ".*\/" "" ""}}{{else}}UniversalAdbDriverSetup.msi{{/if}}</a>
+        <a class="btn btn-primary" href="https://developer.android.com/studio/run/win-usb" role="button" target="_blank" rel="noopener noreferrer" title="Open download source in new tab or window">Get the Google USB Driver ZIP</a>
         <br><br>
         Download this zip file containing ADB & Fastboot from Android SDK
         <br><br>

--- a/templates/layouts/beluga-install.hbs
+++ b/templates/layouts/beluga-install.hbs
@@ -54,9 +54,9 @@
         <br><br>
         <pre><code class="bash">sudo apt install android-tools-adb android-tools-fastboot</code></pre>
         <br>
-        <b>On Windows systems</b> install this ADB driver
+        <b>On Windows systems</b> install the Google USB driver
         <br><br>
-        <a class="btn btn-primary" href="{{#if windowsDrivers}}{{windowsDrivers}}{{else}}http://download.clockworkmod.com/test/UniversalAdbDriverSetup.msi{{/if}}" role="button">{{#if windowsDrivers}}{{replace windowsDrivers ".*\/" "" ""}}{{else}}UniversalAdbDriverSetup.msi{{/if}}</a>
+        <a class="btn btn-primary" href="https://developer.android.com/studio/run/win-usb" role="button" target="_blank" rel="noopener noreferrer" title="Open download source in new tab or window">Get the Google USB Driver ZIP</a>
         <br><br>
         Download this zip file containing ADB & Fastboot from Android SDK
         <br><br>

--- a/templates/layouts/mooneye-install.hbs
+++ b/templates/layouts/mooneye-install.hbs
@@ -54,9 +54,9 @@
         <br><br>
         <pre><code class="bash">sudo apt install android-tools-adb android-tools-fastboot</code></pre>
         <br>
-        <b>On Windows systems</b> install this ADB driver
+        <b>On Windows systems</b> install the Google USB driver
         <br><br>
-        <a class="btn btn-primary" href="{{#if windowsDrivers}}{{windowsDrivers}}{{else}}http://download.clockworkmod.com/test/UniversalAdbDriverSetup.msi{{/if}}" role="button">{{#if windowsDrivers}}{{replace windowsDrivers ".*\/" "" ""}}{{else}}UniversalAdbDriverSetup.msi{{/if}}</a>
+        <a class="btn btn-primary" href="https://developer.android.com/studio/run/win-usb" role="button" target="_blank" rel="noopener noreferrer" title="Open download source in new tab or window">Get the Google USB Driver ZIP</a>
         <br><br>
         Download this zip file containing ADB & Fastboot from Android SDK
         <br><br>


### PR DESCRIPTION
It was noted in the matrix chat that the download source seemed a bit questionable.
In addition, some users reported that it is not working with latest windows versions.

- Link to the Google Developer page containing a ZIP at https://developer.android.com/studio/run/win-usb
- Direct link to the file is not possible
- Open link in new tab/window (browser setting) to not loose the install page scroll state
- Announce the new tab/window using the `title` feature to show a hint on mouse hover.

This fixes https://github.com/AsteroidOS/asteroidos.org/issues/203

Visually:
![grafik](https://user-images.githubusercontent.com/15074193/222719661-c1f3bf08-f42e-495f-8c3e-b7578cf23b0e.png)

