### PR TITLE
Update iOS instructions based on new findings

### DIFF
--- a/pages/wiki/synchronization-clients.md
+++ b/pages/wiki/synchronization-clients.md
@@ -24,7 +24,7 @@ layout: documentation
 
 <p>There is currently no application available for iOS phones to synchronize with AsteroidOS watches. As far as we know, there hasn't been any development done on such an app yet.</p>
 
-<p>However, if the watch is paired with an iOS device, AsteroidOS is capable of displaying notifications from the phone. Pairing can be done using Apple's Bluetooth settings, but several iOS users have reported that a generic BLE scanner/communication app like <a href="https://apps.apple.com/gb/app/nrf-connect-for-mobile/id1054362403">nRF Connect</a> seems to be more reliable for pairing Bluetooth devices. Specific functionality like syncing time or weather forecast are however not supported!</p>
+<p>However, if the watch is paired with an iOS device, AsteroidOS is capable of displaying notifications from the phone. Pairing can only done using 3rd party BLE scanner/communication apps like <a href="https://apps.apple.com/gb/app/nrf-connect-for-mobile/id1054362403">nRF Connect</a> as BLE-only devices do not show up in iOS Bluetooth settings. Specific functionality like syncing time or weather forecast are however not supported!</p>
 
 <div class="page-header">
   <h1 id="sfos">SailfishOS application</h1>


### PR DESCRIPTION
iOS and other iDevices don't show BLE-only devices in the default Bluetooth settings unless they have been paired before.

As such I decided to reword the section again. Feedback is welcome <3

See https://github.com/AsteroidOS/asteroid/issues/241 and specifically https://github.com/AsteroidOS/asteroid/issues/241#issuecomment-1453645841 for more info.