### PR TITLE
Reorder navbar items to present watches and FAQ page more obvious

### DIFF
--- a/templates/includes/nav-main.hbs
+++ b/templates/includes/nav-main.hbs
@@ -13,15 +13,6 @@
     </div>
     <nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
       <ul class="nav navbar-nav navbar-right">
-        {{#is slug 'news'}}
-        <li class="active">
-          <span>News</span>
-        </li>
-        {{else}}
-        <li>
-          <a href="{{rel 'news'}}/">News</a>
-        </li>
-        {{/is}}
         {{#is slug 'watches'}}
         <li class="active">
           <span>Watches</span>
@@ -29,6 +20,15 @@
         {{else}}
         <li>
           <a href="{{rel 'watches'}}/">Watches</a>
+        </li>
+        {{/is}}
+        {{#is slug 'faq'}}
+        <li class="active">
+          <span>FAQ</span>
+        </li>
+        {{else}}
+        <li>
+          <a href="{{rel 'faq'}}/">FAQ</a>
         </li>
         {{/is}}
         {{#is slug 'documentation'}}
@@ -40,13 +40,13 @@
           <a href="{{rel 'wiki/documentation'}}/">Documentation</a>
         </li>
         {{/is}}
-        {{#is slug 'faq'}}
+        {{#is slug 'news'}}
         <li class="active">
-          <span>FAQ</span>
+          <span>News</span>
         </li>
         {{else}}
         <li>
-          <a href="{{rel 'faq'}}/">FAQ</a>
+          <a href="{{rel 'news'}}/">News</a>
         </li>
         {{/is}}
         {{#is slug 'community'}}


### PR DESCRIPTION
After discussion on matrix, this PR reorders the navbar items.
Goal was to move FAQ before Documentation. And proudly feature the Watches page.

![grafik](https://user-images.githubusercontent.com/15074193/222993193-71d165e9-27d2-4933-840e-751dff1d0521.png)
