### PR TITLE
[Featuretable] Fix legend and header flow

### DIFF
--- a/pages/watches/features.md
+++ b/pages/watches/features.md
@@ -6,11 +6,11 @@ layout: featuretable
 
 <h2>Legend</h2>
 <table>
-<tr><td><b>good</b></td><td>The hardware exists and is working</td><td class="support-col good" /></tr>
-<tr><td><b>bad</b></td><td>The hardware exists and is NOT working</td><td class="support-col bad" /></tr>
-<tr><td><b>n/a</b></td><td>The hardware does not exist</td><td class="support-col na"/ ></tr>
-<tr><td><b>partial</b></td><td>The hardware exists but is only partially working</td><td class="support-col partial" /></tr>
-<tr><td><b>unknown</b></td><td>The hardware exists but the status is unknown</td><td class="support-col unknown" /></tr>
+<tr><td class="name-col"><b>good</b></td><td class="legend-col good" /><td>The hardware exists and is working</td></tr>
+<tr><td class="name-col"><b>bad</b></td><td class="legend-col bad" /><td>The hardware exists and is NOT working</td></tr>
+<tr><td class="name-col"><b>n/a</b></td><td class="legend-col na"/ ><td>The hardware does not exist</td></tr>
+<tr><td class="name-col"><b>partial</b></td><td class="legend-col partial" /><td>The hardware exists but is only partially working</td></tr>
+<tr><td class="name-col"><b>unknown</b></td></td><td class="legend-col unknown" /><td>The hardware exists but the status is unknown</tr>
 </table>
 
 <br/>

--- a/styles/components/install-support-table.less
+++ b/styles/components/install-support-table.less
@@ -27,7 +27,7 @@ th.rotated {
   // Make font bold.
   font-weight: 700;
   // Add minimal gap between columns.
-  margin: 0.2VW;
+  margin: 1px;
   padding: 0 !important;
   // for tooltips
   position: relative;
@@ -71,11 +71,25 @@ td.support-col {
   min-width: 15px;
 }
 
-th {
-  min-width: 17px;
+td.legend-col {
+  height: 25px;
+  width: 3.5VW;
+  min-width: 25px;
+  margin: 1px;
 }
+
+th {
+  min-width: 15px;
+  font-size: 0.9em;
+  margin: 1px;
+
+  @media (min-width: @grid-float-breakpoint) {
+    font-size: 1em;
+  }
+}
+
 .name-col {
-    min-width: 70px;
+  min-width: 70px;
 }
 
 .good {

--- a/styles/components/install-support-table.less
+++ b/styles/components/install-support-table.less
@@ -15,6 +15,7 @@ th.rotated {
     height: 40px;
     white-space: nowrap;
     transform: translateX(10px) rotate(-45deg);
+    text-align: center;
 }
 
 .support-col {
@@ -26,7 +27,7 @@ th.rotated {
   // Make font bold.
   font-weight: 700;
   // Add minimal gap between columns.
-  margin: 1px;
+  margin: 0.2VW;
   padding: 0 !important;
   // for tooltips
   position: relative;
@@ -74,7 +75,7 @@ th {
   min-width: 17px;
 }
 .name-col {
-    width: 90px;
+    min-width: 70px;
 }
 
 .good {


### PR DESCRIPTION
Fixed
- The the rotated class did not scale to the same width like the support-col. Driving the headers off center
- Legend support-col was too low min-width and looked too narrow

![grafik](https://user-images.githubusercontent.com/15074193/223284464-6235cd41-9e99-4de5-847f-bdd47f4ca961.png)

![grafik](https://user-images.githubusercontent.com/15074193/223284423-a37ed5b4-022e-4fb3-ac97-6f8e708286c1.png)
