### PR TITLE
Add markdown for news items

### DIFF
--- a/templates/layouts/news.hbs
+++ b/templates/layouts/news.hbs
@@ -15,9 +15,9 @@
         <img src="/public/img/news-thumbnails/{{ thumbnails }}.jpg" width="100%" />
         <br><br><br>
       </div>
-
-      {{> body }}
-
+      {{#markdown}}
+        {{> body}}
+      {{/markdown}}
       <hr>
       <div style="float: right; color: #888">Written by {{ author }} on the {{dateFormat posted "DD/MM/YYYY"}}</div>
     </div>


### PR DESCRIPTION
This makes a minor adaptation to the news template to allow authors to write news items using markdown syntax.  This may help #260 and #279