### PR TITLE
Fix edit pen github link

### DIFF
--- a/templates/includes/popover-source-link.hbs
+++ b/templates/includes/popover-source-link.hbs
@@ -1,9 +1,9 @@
 {{!-- the trigger link --}}
 
-<a class="icon ion-md-create  source-link right" style="float: right;" href="https://github.com/AsteroidOS/asteroidos.org/blob/master/pages/wiki/{{this.basename}}.hbs" data-content="{{this.basename}}" target="_blank"></a>
+<a class="icon ion-md-create  source-link right" style="float: right;" href="https://github.com/AsteroidOS/asteroidos.org/blob/master/{{page.filePair.src}}" data-content="{{this.basename}}" target="_blank"></a>
 
 
 {{!-- the popover link. this is dynamically inserted into the popover template by ./assets/public/js/application.js --}}
-<a id="{{this.basename}}" href="https://github.com/AsteroidOS/asteroidos.org/edit/master/pages/wiki/{{this.basename}}.md" target="_blank">Edit the content of this page
+<a id="{{this.basename}}" href="https://github.com/AsteroidOS/asteroidos.org/edit/master/{{page.filePair.src}}" target="_blank">Edit the content of this page
   <span class="icon ion-md-open"></span>
 </a>


### PR DESCRIPTION
This fixes issue #271 by correctly constructing the link to the github source page no matter where in the hierarchy the page exists.