### PR TITLE
Restructure ADB unlock steps

### DIFF
--- a/templates/includes/install-unlock-adb-beluga.hbs
+++ b/templates/includes/install-unlock-adb-beluga.hbs
@@ -1,40 +1,50 @@
-      <h2>1. Unlock your bootloader</h2>
-      Installing AsteroidOS requires an unlocked bootloader.
-      <br>Accessing the fastboot bootloader menu on your watch can be achieved via ADB in Wear OS, as described below in step 1.1.
-      <br>You can skip to step 1.2 if you are familiar with the manual method to access the bootloader menu. The methods are explained on the <a href="https://asteroidos.org/wiki/useful-commands/#boot-to-fastboot-bootloader-menu">useful commands page</a>.
-      <h3>1.1 Enable ADB on your watch with the following steps:</h3>
-      <div class="unlock-adb-wrapper">
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-beluga-01.webp" class="unlock-step-img">
-          <div class="unlock-step-text">1. Open the <b>settings</b> app</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-beluga-02.webp" class="unlock-step-img">
-          <div class="unlock-step-text">2. Open the <b>System</b> page</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-beluga-03.webp" class="unlock-step-img">
-          <div class="unlock-step-text">3. Open the <b>About</b> page</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-beluga-04.webp" class="unlock-step-img">
-          <div class="unlock-step-text">4. Tap the <b>Build number</b> 7 times to reveal Developer options</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-beluga-01.webp" class="unlock-step-img">
-          <div class="unlock-step-text">5. Open the <b>Settings</b> app again</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-beluga-05.webp" class="unlock-step-img">
-          <div class="unlock-step-text">6. Open the <b>Developer options</b> page</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-beluga-06.webp" class="unlock-step-img">
-          <div class="unlock-step-text">7. Enable <b>ADB debugging</b> and <b>OEM unlock</b></div>
-        </div>
-      </div>
-      <h3>1.2 Use fastboot to unlock the bootloader</h3>
-      <br>Enter the following commands in a terminal with your watch connected to USB</li>
-      <br><pre><code class="bash">adb reboot bootloader<br>fastboot oem unlock</code></pre>
-      Follow the instructions on your watch's screen. <b>Please note it may void your warranty.</b>
-      <br><br>
+{{!-- Unlock Adb Beluga --}}
+<h2>1. Unlock your bootloader</h2>
+<div class="callout callout-warning">
+  <h4>Note</h4>
+  Unlocking the bootloader may void your warranty.
+  <br>The unlock process will trigger a factory reset of Wear OS. Backup any data you do not want to loose.
+</div>
+Installing AsteroidOS requires an unlocked bootloader.
+<br>Accessing the fastboot bootloader menu on your watch can be achieved using ADB in Wear OS, as described below in step 1.1.
+<br>If you are familiar with the manual method to access the bootloader menu, you can <a href="#skip-adb-unlock">skip to step 1.3</a>. Those methods are explained on the <a href="https://asteroidos.org/wiki/useful-commands/#boot-to-fastboot-bootloader-menu">useful commands page</a>.
+<h3>1.1 Enable ADB on your watch</h3>
+<div class="unlock-adb-wrapper">
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-beluga-01.webp" class="unlock-step-img">
+    <div class="unlock-step-text">1. Open the <b>settings</b> app</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-beluga-02.webp" class="unlock-step-img">
+    <div class="unlock-step-text">2. Open the <b>System</b> page</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-beluga-03.webp" class="unlock-step-img">
+    <div class="unlock-step-text">3. Open the <b>About</b> page</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-beluga-04.webp" class="unlock-step-img">
+    <div class="unlock-step-text">4. Tap the <b>Build number</b> 7 times to reveal Developer options</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-beluga-01.webp" class="unlock-step-img">
+    <div class="unlock-step-text">5. Open the <b>Settings</b> app again</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-beluga-05.webp" class="unlock-step-img">
+    <div class="unlock-step-text">6. Open the <b>Developer options</b> page</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-beluga-06.webp" class="unlock-step-img">
+    <div class="unlock-step-text">7. Enable <b>ADB debugging</b> and <b>OEM unlock</b></div>
+  </div>
+</div>
+<h3>1.2 Reboot to fastboot bootloader mode</h3>
+Enter the following ADB command in a terminal with your watch connected to USB.
+<a id="skip-adb-unlock"></a>
+<br><pre><code class="bash">adb reboot bootloader</code></pre>
+<h3>1.3 Use fastboot to unlock the bootloader</h3>
+With your watch now in fastboot mode, enter this command in a terminal to start the unlock procedure.
+<pre><code class="bash">fastboot oem unlock</code></pre>
+<h3>1.4 Follow the instructions on your watch's screen</h3><b>Please note again, this may void your warranty and will wipe your userdata.</b>
+<br><br>

--- a/templates/includes/install-unlock-adb-round.hbs
+++ b/templates/includes/install-unlock-adb-round.hbs
@@ -1,41 +1,50 @@
 {{!-- Unlock Adb Round --}}
-      <h2>1. Unlock your bootloader</h2>
-      Installing AsteroidOS requires an unlocked bootloader.
-      <br>Accessing the fastboot bootloader menu on your watch can be achieved via ADB in Wear OS, as described below in step 1.1.
-      <br>You can skip to step 1.2 if you are familiar with the manual method to access the bootloader menu. The methods are explained on the <a href="https://asteroidos.org/wiki/useful-commands/#boot-to-fastboot-bootloader-menu">useful commands page</a>.
-      <h3>1.1 Enable ADB on your watch with the following steps:</h3>
-      <div class="unlock-adb-wrapper">
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-aw-01.webp" class="unlock-step-img">
-          <div class="unlock-step-text">1. Open the <b>settings</b> app</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-aw-02.webp" class="unlock-step-img">
-          <div class="unlock-step-text">2. Open the <b>System</b> page</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-aw-03.webp" class="unlock-step-img">
-          <div class="unlock-step-text">3. Open the <b>About</b> page</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-aw-04.webp" class="unlock-step-img">
-          <div class="unlock-step-text">4. Tap the <b>Build number</b> 7 times to reveal Developer options</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-aw-01.webp" class="unlock-step-img">
-          <div class="unlock-step-text">5. Open the <b>Settings</b> app again</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-aw-05.webp" class="unlock-step-img">
-          <div class="unlock-step-text">6. Open the <b>Developer options</b> page</div>
-        </div>
-        <div class="unlock-step-wrapper">
-          <img src="{{assets}}/img/install-aw-06.webp" class="unlock-step-img">
-          <div class="unlock-step-text">7. Enable <b>ADB debugging</b></div>
-        </div>
-      </div>
-      <h3>1.2 Use fastboot to unlock the bootloader</h3>
-      <br>Enter the following commands in a terminal with your watch connected to USB</li>
-      <br><pre><code class="bash">adb reboot bootloader<br>fastboot oem unlock</code></pre>
-      Follow the instructions on your watch's screen. <b>Please note it may void your warranty.</b>
-      <br><br>
+<h2>1. Unlock your bootloader</h2>
+<div class="callout callout-warning">
+  <h4>Note</h4>
+  Unlocking the bootloader may void your warranty.
+  <br>The unlock process will trigger a factory reset of Wear OS. Backup any data you do not want to loose.
+</div>
+Installing AsteroidOS requires an unlocked bootloader.
+<br>Accessing the fastboot bootloader menu on your watch can be achieved using ADB in Wear OS, as described below in step 1.1.
+<br>If you are familiar with the manual method to access the bootloader menu, you can <a href="#skip-adb-unlock">skip to step 1.3</a>. Those methods are explained on the <a href="https://asteroidos.org/wiki/useful-commands/#boot-to-fastboot-bootloader-menu">useful commands page</a>.
+<h3>1.1 Enable ADB on your watch</h3>
+<div class="unlock-adb-wrapper">
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-aw-01.webp" class="unlock-step-img">
+    <div class="unlock-step-text">1. Open the <b>settings</b> app</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-aw-02.webp" class="unlock-step-img">
+    <div class="unlock-step-text">2. Open the <b>System</b> page</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-aw-03.webp" class="unlock-step-img">
+    <div class="unlock-step-text">3. Open the <b>About</b> page</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-aw-04.webp" class="unlock-step-img">
+    <div class="unlock-step-text">4. Tap the <b>Build number</b> 7 times to reveal Developer options</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-aw-01.webp" class="unlock-step-img">
+    <div class="unlock-step-text">5. Open the <b>Settings</b> app again</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-aw-05.webp" class="unlock-step-img">
+    <div class="unlock-step-text">6. Open the <b>Developer options</b> page</div>
+  </div>
+  <div class="unlock-step-wrapper">
+    <img src="{{assets}}/img/install-aw-06.webp" class="unlock-step-img">
+    <div class="unlock-step-text">7. Enable <b>ADB debugging</b></div>
+  </div>
+</div>
+<h3>1.2 Reboot to fastboot bootloader mode</h3>
+Enter the following ADB command in a terminal with your watch connected to USB.
+<a id="skip-adb-unlock"></a>
+<br><pre><code class="bash">adb reboot bootloader</code></pre>
+<h3>1.3 Use fastboot to unlock the bootloader</h3>
+With your watch now in fastboot mode, enter this command in a terminal to start the unlock procedure.
+<pre><code class="bash">fastboot oem unlock</code></pre>
+<h3>1.4 Follow the instructions on your watch's screen</h3><b>Please note again, this may void your warranty and will wipe your userdata.</b>
+<br><br>


### PR DESCRIPTION
Following the move of the instructions into an include block, this PR polishes and restructures the instruction steps to be even clearer.

- Add step 1.3 and 1.4 to explain every actual step the user has to take in detail and be able to reference it in chat. And make the steps more obvious by thus giving all of them a `<h3>` header.
- Add prominent hint that the unlock procedure will factory reset the device and the warranty might void..
- Add anchor and link to "skip to step 1.3" for users familiar with the manual methods. The anchor needs to be placed one line above the actual anchor target to account for the menu navbar.
- Reformulate much of the text for better flow
- Shorten 1.1 to "1.1 Enable ADB on your watch", omitting the "with the following steps:"
- Remove `.` and `:` from headlines

![grafik](https://user-images.githubusercontent.com/15074193/225925520-671ba2fe-c38d-447e-a50a-716afa1235e1.png)
![grafik](https://user-images.githubusercontent.com/15074193/225925671-40b49bd3-2fc9-49b9-841e-8a598d3f90df.png)
