### PR TITLE
Add backup instructions

### DIFF
--- a/pages/wiki/backup.md
+++ b/pages/wiki/backup.md
@@ -5,23 +5,25 @@ layout: documentation
 
 Before flashing AsteroidOS to your watch to replace WearOS, we advise to make a backup.
 
-# Manual method
+# Manual backup method
 
-## 1. Temporarily install AsteroidOS
+### 1. Temporarily install AsteroidOS
 
-Follow the install instructions for a temporary installation. Once booted into AsteroidOS, we can enable adb with root access to all partitions on the internal storage.
+Follow the install instructions for a temporary installation. Once booted into AsteroidOS, we can enable SSH or ADB with root access to all partitions on the internal storage.
 
-## 2. Enable Developer Mode
+### 2. Enable SSH or ADB
 
-Open the settings app and the USB page. Select Developer mode to enable SSH.
+Open the settings app and the USB page. Select Developer mode to enable SSH. Or ADB mode to use ADB connection.
 
-## 3. Copy mmcblk0 into a local image file
+### 3. Copy mmcblk0 into a local image file
 
+#### 3.a Backup using SSH and `dd`
 Navigate to a folder where you want to store the backup. Or add a full path before the image name (after `of=`) in the next command.
 
-    ssh root@192.168.2.15 "dd if=/dev/mmcblk0" | dd "of=original-watch-backup.img" bs=4096 status=progress
+    ssh root@192.168.2.15 "dd if=/dev/mmcblk0" | dd "of=watch-backup.img" bs=4096 status=progress
+
+#### 3.b Backup using ADB
+
+    adb pull /dev/mmcblk0/watch-backup.img
 
 The copy process might take up to an hour on watches with 8GB storage.
-
-# Scripted method
-

--- a/pages/wiki/backup.md
+++ b/pages/wiki/backup.md
@@ -1,9 +1,9 @@
 ---
-title: Backup Wear OS
+title: Backup Guide
 layout: documentation
 ---
 
-Before flashing AsteroidOS to your watch to replace WearOS, we advise to make a backup.
+Before flashing AsteroidOS to your watch to replace WearOS, we advise to make a complete backup.
 
 # Manual backup method
 
@@ -27,3 +27,40 @@ Navigate to a folder where you want to store the backup. Or add a full path befo
     adb pull /dev/mmcblk0/watch-backup.img
 
 The copy process might take up to an hour on watches with 8GB storage.
+
+
+# Scripted backup and restore
+
+### 1. Clone asteroid-hosttools
+
+Beroset has written a set of tools to make working with watches from a linux computer very convenient. This backup guide will only cover the backup and restore features of asteroid-hosttools. Please be sure to read the [asteroid-hosttools documentation](https://github.com/beroset/asteroid-hosttools) to make use of the full capabilities they provide.\
+Clone the asteroid-hosttools using the following command:
+```
+git clone https://github.com/beroset/asteroid-hosttools
+```
+And change into the asteroid-hosttools directory:
+```
+cd asteroid-hosttools
+```
+
+### 2. Temporarily install AsteroidOS
+
+Adapt `<watch-codename>` in the following commands according to your watches codename listed on the [Watches page](https://asteroidos.org/watches/). I.e `dory` for the LG G Watch or `sturgeon` for the Huawei Watch.
+```
+./flashy <watch-codename> --temp --nightly
+```
+
+### 3. Backup the entire watch
+
+Following command will create a file called `original-<watch-codename>.img`.
+```
+./watch-image <watch-codename> --save
+```
+
+### 4. Restore a backup
+
+To restore the backup image created in step 3, make sure the `original-<watch-codename>.img` file exists.\
+Then issue the restore command:
+```
+./watch-image <watch-codename> --restore
+```

--- a/pages/wiki/backup.md
+++ b/pages/wiki/backup.md
@@ -1,0 +1,27 @@
+---
+title: Backup Wear OS
+layout: documentation
+---
+
+Before flashing AsteroidOS to your watch to replace WearOS, we advise to make a backup.
+
+# Manual method
+
+## 1. Temporarily install AsteroidOS
+
+Follow the install instructions for a temporary installation. Once booted into AsteroidOS, we can enable adb with root access to all partitions on the internal storage.
+
+## 2. Enable Developer Mode
+
+Open the settings app and the USB page. Select Developer mode to enable SSH.
+
+## 3. Copy mmcblk0 into a local image file
+
+Navigate to a folder where you want to store the backup. Or add a full path before the image name (after `of=`) in the next command.
+
+    ssh root@192.168.2.15 "dd if=/dev/mmcblk0" | dd "of=original-watch-backup.img" bs=4096 status=progress
+
+The copy process might take up to an hour on watches with 8GB storage.
+
+# Scripted method
+

--- a/pages/wiki/documentation.md
+++ b/pages/wiki/documentation.md
@@ -9,7 +9,7 @@ layout: documentation
       <h1 id="users">Users</h1>
     </div>
     <ul>
-      <li><a href="{{rel 'wiki/backup'}}">Backup Wear OS</a></li>
+      <li><a href="{{rel 'wiki/backup'}}">Backup Guide</a></li>
       <li><a href="{{rel 'wiki/synchronization-clients'}}">Synchronization Clients</a></li>
       <li><a href="{{rel 'wiki/porting-status'}}">Porting Status</a></li>
       <li><a href="{{rel 'wiki/useful-commands'}}">Useful Commands</a></li>

--- a/pages/wiki/documentation.md
+++ b/pages/wiki/documentation.md
@@ -9,6 +9,7 @@ layout: documentation
       <h1 id="users">Users</h1>
     </div>
     <ul>
+      <li><a href="{{rel 'wiki/backup'}}">Backup Wear OS</a></li>
       <li><a href="{{rel 'wiki/synchronization-clients'}}">Synchronization Clients</a></li>
       <li><a href="{{rel 'wiki/porting-status'}}">Porting Status</a></li>
       <li><a href="{{rel 'wiki/useful-commands'}}">Useful Commands</a></li>


### PR DESCRIPTION
Draft that has

- Manual backup instructions using adb and ssh

And misses:

- Srcipted method describing berosets host-tools
- Restore involving magenfires partition extraction script