### PR TITLE
Remove piwik analytics stuff from head

### DIFF
--- a/templates/includes/head.hbs
+++ b/templates/includes/head.hbs
@@ -31,19 +31,3 @@
 
 <!-- Favicons -->
 <link rel="shortcut icon" href="{{ assets }}/ico/favicon.ico">
-
-
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = _paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//stat.asteroidos.org/";
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', '1']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>


### PR DESCRIPTION
According to @jrtberlin on matrix "We don't have a service under that subdomain. We can remove all references to the analytics stuff"