### PR TITLE
Reorder and streamline topics

### DIFF
--- a/pages/wiki/documentation.md
+++ b/pages/wiki/documentation.md
@@ -17,7 +17,6 @@ layout: documentation
       <li><a href="{{rel 'wiki/ip-connection'}}">IP Connection</a></li>
       <li><a href="{{rel 'wiki/update-asteroidos'}}">Update AsteroidOS</a></li>
       <li><a href="{{rel 'wiki/package-installation'}}">Manual Watchface and Package Installation</a></li>
-      <li><a href="{{rel 'wiki/bluetooth'}}">Bluetooth</a></li>
       <li><a href="{{rel 'wiki/translating-asteroidos'}}">Translating AsteroidOS</a></li>
       <li><a href="{{rel 'wiki/licenses'}}">Licenses</a></li>
       <li><a href="{{rel 'wiki/code-of-conduct'}}">Code of Conduct</a></li>
@@ -34,12 +33,13 @@ layout: documentation
       <li><a href="{{rel 'wiki/watchfaces-creation'}}">Watchfaces creation</a></li>
       <li><a href="{{rel 'wiki/emulator'}}">Emulator</a></li>
       <li><a href="{{rel 'wiki/localweb'}}">Local version of asteroidos.org</a></li>
-      <li><a href="{{rel 'wiki/ble-profiles'}}">Bluetooth Low Energy Profiles</a></li>
-      <li><a href="{{rel 'wiki/conferences'}}">Conferences</a></li>
       <li><a href="{{rel 'wiki/porting-guide'}}">Porting Guide</a></li>
       <li><a href="{{rel 'wiki/openembedded'}}">OpenEmbedded</a></li>
       <li><a href="{{rel 'wiki/boot-process'}}">Boot Process</a></li>
       <li><a href="{{rel 'wiki/graphic-stack'}}">Graphic Stack</a></li>
+      <li><a href="{{rel 'wiki/bluetooth'}}">Bluetooth</a></li>
+      <li><a href="{{rel 'wiki/ble-profiles'}}">Bluetooth Low Energy Profiles</a></li>
+      <li><a href="{{rel 'wiki/conferences'}}">Conferences</a></li>
     </ul>
   </div>
 </div>

--- a/pages/wiki/documentation.md
+++ b/pages/wiki/documentation.md
@@ -16,7 +16,7 @@ layout: documentation
       <li><a href="{{rel 'wiki/ssh'}}">SSH</a></li>
       <li><a href="{{rel 'wiki/ip-connection'}}">IP Connection</a></li>
       <li><a href="{{rel 'wiki/update-asteroidos'}}">Update AsteroidOS</a></li>
-      <li><a href="{{rel 'wiki/package-installation'}}">Manual Watchface and Package Installation</a></li>
+      <li><a href="{{rel 'wiki/package-installation'}}">Watchface and Package Installation</a></li>
       <li><a href="{{rel 'wiki/translating-asteroidos'}}">Translating AsteroidOS</a></li>
       <li><a href="{{rel 'wiki/licenses'}}">Licenses</a></li>
       <li><a href="{{rel 'wiki/code-of-conduct'}}">Code of Conduct</a></li>

--- a/pages/wiki/documentation.md
+++ b/pages/wiki/documentation.md
@@ -11,15 +11,15 @@ layout: documentation
     <ul>
       <li><a href="{{rel 'wiki/backup'}}">Backup Guide</a></li>
       <li><a href="{{rel 'wiki/synchronization-clients'}}">Synchronization Clients</a></li>
-      <li><a href="{{rel 'wiki/porting-status'}}">Porting Status</a></li>
-      <li><a href="{{rel 'wiki/useful-commands'}}">Useful Commands</a></li>
-      <li><a href="{{rel 'wiki/ssh'}}">SSH</a></li>
-      <li><a href="{{rel 'wiki/ip-connection'}}">IP Connection</a></li>
-      <li><a href="{{rel 'wiki/update-asteroidos'}}">Update AsteroidOS</a></li>
       <li><a href="{{rel 'wiki/package-installation'}}">Watchface and Package Installation</a></li>
+      <li><a href="{{rel 'wiki/update-asteroidos'}}">Update AsteroidOS</a></li>
+      <li><a href="{{rel 'wiki/ip-connection'}}">IP Connection</a></li>
+      <li><a href="{{rel 'wiki/ssh'}}">SSH</a></li>
+      <li><a href="{{rel 'wiki/useful-commands'}}">Useful Commands</a></li>
+      <li><a href="{{rel 'wiki/porting-status'}}">Porting Status</a></li>
       <li><a href="{{rel 'wiki/translating-asteroidos'}}">Translating AsteroidOS</a></li>
-      <li><a href="{{rel 'wiki/licenses'}}">Licenses</a></li>
       <li><a href="{{rel 'wiki/code-of-conduct'}}">Code of Conduct</a></li>
+      <li><a href="{{rel 'wiki/licenses'}}">Licenses</a></li>
     </ul>
   </div>
 

--- a/pages/wiki/package-installation.md
+++ b/pages/wiki/package-installation.md
@@ -1,5 +1,5 @@
 ---
-title: Manual Watchface and Package Installation
+title: Watchface and Package Installation
 layout: documentation
 ---
 


### PR DESCRIPTION
- Move Bluetooth to developers since it clearly says "Technical details..."
- Sort developer porting related topics in row
- Move conferences down since its unrelated to other topics
- Rename Manual Watchface and Package installation to just Watchface and Package installation
- Sort Users topics by priority new users seeking general information would expect after having read the FAQ

New layout:
![image](https://user-images.githubusercontent.com/15074193/230379641-ebc3037b-21b6-4dec-b793-93eb91ba20e6.png)
