### PR TITLE
Rename Developer Mode to SSH Mode

### DIFF
--- a/pages/wiki/backup.md
+++ b/pages/wiki/backup.md
@@ -13,7 +13,7 @@ Follow the install instructions for a temporary installation. Once booted into A
 
 ### 2. Enable SSH or ADB
 
-Open the settings app and the USB page. Select Developer mode to enable SSH. Or ADB mode to use ADB connection.
+Open the settings app and the USB page. Select SSH Mode to enable SSH. Or ADB Mode to use ADB connection.
 
 ### 3. Copy mmcblk0 into a local image file
 

--- a/pages/wiki/useful-commands.md
+++ b/pages/wiki/useful-commands.md
@@ -78,7 +78,7 @@ In AsteroidOS, the USB mode is handled by a daemon named usb_moded. This daemon 
 ```
 usb_moded_util -m # Returns a list of supported modes
 usb_moded_util -q # Shows the currently used USB mode
-usb_moded_util -s adb_mode # Set USB to the ADB mode
+usb_moded_util -s adb_mode # Set USB to the ADB Mode
 ```
 
 # Screen

--- a/pages/wiki/watchfaces-creation.md
+++ b/pages/wiki/watchfaces-creation.md
@@ -84,7 +84,7 @@ Do not ever forget to brag all over the internet with your cool new watchface an
 
 Use the `./watchface` script to copy your watchface creation to the watch using either SCP or ADB commands.
 
-Connect your AsteroidOS Watch, configured to either ADB Mode (ADB transfer) or Developer Mode (SCP transfer) in Settings &rarr; USB.
+Connect your AsteroidOS Watch, configured to either ADB Mode (ADB transfer) or SSH Mode (SCP transfer) in Settings &rarr; USB.
 
 Start `./watchface` to use SCP commands or `./watchface -a` for ADB commands.
 

--- a/templates/includes/install-temp.hbs
+++ b/templates/includes/install-temp.hbs
@@ -1,6 +1,6 @@
         <div name="LinTemp" style="display: block">
           <h3>2.2 Temporary installation using Linux</h3>
-          Reboot to Wear OS, re-enable developer mode and ADB debugging like shown in steps 1.1.1 - 1.1.7.
+          Reboot to Wear OS, re-enable Developer options and ADB debugging like shown in steps 1.1.1 - 1.1.7.
           <br>Note, you can access the Wear OS settings app via long press of the power button already while the initial pairing screen is shown.
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
@@ -33,7 +33,7 @@
 
         <div name="WinTemp" style="display: none">
           <h3>2.2 Temporary installation using Windows</h3>
-          Reboot to Wear OS, re-enable developer mode and ADB debugging like shown in steps 1.1.1 - 1.1.7.
+          Reboot to Wear OS, re-enable Developer options and ADB debugging like shown in steps 1.1.1 - 1.1.7.
           <br>Note, you can access the Wear OS settings app via long press of the power button already while the initial pairing screen is shown.
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">

--- a/templates/includes/install-unlock-adb-beluga.hbs
+++ b/templates/includes/install-unlock-adb-beluga.hbs
@@ -72,7 +72,7 @@
   <h3>1.a Manual method</h3>
   Long press the power button for up to 10 seconds until the watch reboots. Then quickly perform a key combination or sequence right when the watch powers on again, to stop the boot process at the fastboot screen. The specific key combination for your watch is explained on the <a href="https://asteroidos.org/wiki/useful-commands/#boot-to-fastboot-bootloader-menu">useful commands page</a>.
   <h3>1.b Using ADB</h3>
-  Set <b>ADB-Mode</b> in the <b>USB</b> page of the AsteroidOS <b>Settings</b> app.
+  Set <b>ADB Mode</b> in the <b>USB</b> page of the AsteroidOS <b>Settings</b> app.
   <br>Enter the following ADB command in a terminal with your watch connected to USB.
   <div class="install-code-wrapper">
     <div class="install-code-pre-wrapper">
@@ -84,7 +84,7 @@
   </div>
   <div name="LinuxSsh" style="display: none">
     <h3>1.c Using SSH</h3>
-    Set <b>Developer-Mode</b> in the <b>USB</b> page of the AsteroidOS <b>Settings</b> app.
+    Set <b>SSH Mode</b> in the <b>USB</b> page of the AsteroidOS <b>Settings</b> app.
     <br>Enter the following SSH command in a terminal with your watch connected to USB.
     <div class="install-code-wrapper">
       <div class="install-code-pre-wrapper">

--- a/templates/includes/install-unlock-adb-round.hbs
+++ b/templates/includes/install-unlock-adb-round.hbs
@@ -72,7 +72,7 @@
   <h3>1.a Manual method</h3>
   Long press the power button for up to 10 seconds until the watch reboots. Then quickly perform a key combination or sequence right when the watch powers on again, to stop the boot process at the fastboot screen. The specific key combination for your watch is explained on the <a href="https://asteroidos.org/wiki/useful-commands/#boot-to-fastboot-bootloader-menu">useful commands page</a>.
   <h3>1.b Using ADB</h3>
-  Set <b>ADB-Mode</b> in the <b>USB</b> page of the AsteroidOS <b>Settings</b> app.
+  Set <b>ADB Mode</b> in the <b>USB</b> page of the AsteroidOS <b>Settings</b> app.
   <br>Enter the following ADB command in a terminal with your watch connected to USB.
   <div class="install-code-wrapper">
     <div class="install-code-pre-wrapper">
@@ -84,7 +84,7 @@
   </div>
   <div name="LinuxSsh" style="display: none">
     <h3>1.c Using SSH</h3>
-    Set <b>Developer-Mode</b> in the <b>USB</b> page of the AsteroidOS <b>Settings</b> app.
+    Set <b>SSH Mode</b> in the <b>USB</b> page of the AsteroidOS <b>Settings</b> app.
     <br>Enter the following SSH command in a terminal with your watch connected to USB.
     <div class="install-code-wrapper">
       <div class="install-code-pre-wrapper">


### PR DESCRIPTION
And unify ADB Mode, Developer options and ADB debugging

Fixes https://github.com/AsteroidOS/asteroid-settings/issues/65

Needs to be merged in sync with to be created PR in asteroid-settings to actually rename from Developer mode and add translation string for SSH Mode.