### PR TITLE
watches: Reduce width on smaller screen widths.

### DIFF
--- a/styles/components/install-box.less
+++ b/styles/components/install-box.less
@@ -35,12 +35,12 @@
   }
 
   @media (min-width: @screen-sm-min) {
-    width: 31.2%;
+    width: 31%;
     margin: 0.9%
   }
 
   @media (min-width: @screen-md-min) {
-    width: 23.3%;
+    width: 23%;
     margin: 0.7%
   }
 


### PR DESCRIPTION
This ensures that there's enough space available such that there's no empty space on the right on the watches page.

Here's a before and after of the phenomenon.
![image](https://user-images.githubusercontent.com/7857908/230885151-987e0164-d5f0-4e20-8cc6-c53697e1d401.png)
