### PR TITLE
Fix featuretable alignment

### DIFF
--- a/styles/components/install-support-table.less
+++ b/styles/components/install-support-table.less
@@ -89,7 +89,7 @@ th {
 }
 
 .name-col {
-  min-width: 70px;
+  min-width: 74px;
 }
 
 .good {


### PR DESCRIPTION
This fixes #349 by slightly enlarging the width of the name column to accomodate inharmony, which is currently the longest name.