### PR TITLE
Add unicode slug to watches, news and documentation header

### DIFF
--- a/templates/includes/documentation-header.hbs
+++ b/templates/includes/documentation-header.hbs
@@ -4,11 +4,7 @@
     <h1>
     {{#is slug 'documentation'}}
     {{else}}
-      <a href="{{rel 'wiki/documentation'}}">Documentation</a> <svg width="4.3482mm" height="6.0193mm" version="1.1" viewBox="0 0 6.9570877 9.6308298">
-<g transform="translate(-73.598 -103.17)">
-<g transform="translate(1.6)" fill="#666">
-<path d="m73.598 103.17h0.85725l2.8998 4.8154-2.8998 4.8154h-0.85725l2.8892-4.8154z" fill="#666" stroke-width=".26458"/>
-</g></g></svg> {{/is}}
+      <a href="{{rel 'wiki/documentation'}}">Documentation</a> ⟩ {{/is}}
     {{ title }}</h1>{{> popover-source-link . }}
   </div>
 </div>

--- a/templates/includes/documentation-header.hbs
+++ b/templates/includes/documentation-header.hbs
@@ -4,7 +4,7 @@
     <h1>
     {{#is slug 'documentation'}}
     {{else}}
-      <a href="{{rel 'wiki/documentation'}}">Documentation</a> ⟩ {{/is}}
+      <a href="{{rel 'wiki/documentation'}}">Documentation</a> &#x27e9; {{/is}}
     {{ title }}</h1>{{> popover-source-link . }}
   </div>
 </div>

--- a/templates/includes/news-header.hbs
+++ b/templates/includes/news-header.hbs
@@ -1,10 +1,6 @@
 {{!-- Header --}}
 <div class="docs-header" id="content">
   <div class="container">
-    <h1><a href="{{rel 'news'}}">News</a> <svg width="4.3482mm" height="6.0193mm" version="1.1" viewBox="0 0 6.9570877 9.6308298">
-<g transform="translate(-73.598 -103.17)">
-<g transform="translate(1.6)" fill="#666">
-<path d="m73.598 103.17h0.85725l2.8998 4.8154-2.8998 4.8154h-0.85725l2.8892-4.8154z" fill="#666" stroke-width=".26458"/>
-</g></g></svg> {{ title }}</h1>
+    <h1><a href="{{rel 'news'}}">News</a> ⟩ {{ title }}</h1>
   </div>
 </div>

--- a/templates/includes/news-header.hbs
+++ b/templates/includes/news-header.hbs
@@ -1,6 +1,6 @@
 {{!-- Header --}}
 <div class="docs-header" id="content">
   <div class="container">
-    <h1><a href="{{rel 'news'}}">News</a> ⟩ {{ title }}</h1>
+    <h1><a href="{{rel 'news'}}">News</a> &#x27e9; {{ title }}</h1>
   </div>
 </div>

--- a/templates/includes/watches-header.hbs
+++ b/templates/includes/watches-header.hbs
@@ -1,6 +1,6 @@
 {{!-- Header --}}
 <div class="docs-header" id="content">
   <div class="container">
-    <h1><a href="/watches/">Watches</a> ⟩ {{ title }}</h1>
+    <h1><a href="/watches/">Watches</a> &#x27e9; {{ title }}</h1>
   </div>
 </div>

--- a/templates/includes/watches-header.hbs
+++ b/templates/includes/watches-header.hbs
@@ -1,10 +1,6 @@
 {{!-- Header --}}
 <div class="docs-header" id="content">
   <div class="container">
-    <h1><a href="/watches/">Watches</a> <svg width="4.3482mm" height="6.0193mm" version="1.1" viewBox="0 0 6.9570877 9.6308298">
-<g transform="translate(-73.598 -103.17)">
-<g transform="translate(1.6)" fill="#666">
-<path d="m73.598 103.17h0.85725l2.8998 4.8154-2.8998 4.8154h-0.85725l2.8892-4.8154z" fill="#666" stroke-width=".26458"/>
-</g></g></svg> {{ title }}</h1>
+    <h1><a href="/watches/">Watches</a> ⟩ {{ title }}</h1>
   </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/AsteroidOS/asteroidos.org/issues/343 by swapping the svg slug for unicode char U+27E9.

![grafik](https://user-images.githubusercontent.com/15074193/232167772-429dc338-4b5b-418e-b212-3e2f490aeac3.png)
![grafik](https://user-images.githubusercontent.com/15074193/232167792-916afb36-d3ff-41b2-86c6-69a4c27e5996.png)
![grafik](https://user-images.githubusercontent.com/15074193/232167823-cfdca325-743f-4677-8161-e5a4298df333.png)
