### PR TITLE
Translate hint

### DIFF
--- a/pages/wiki/creating-an-asteroid-app.md
+++ b/pages/wiki/creating-an-asteroid-app.md
@@ -175,7 +175,7 @@ vim scp://ceres@192.168.2.15//path/to/file.qml
 
 ---
 
-Here is a shell script to quickly install an app:
+Here is a shell script to quickly build and install an app:
 
 ```
 #!/bin/sh
@@ -183,16 +183,12 @@ Here is a shell script to quickly install an app:
 source /usr/local/oecore-x86_64/environment-setup-armv7vehf-neon-oe-linux-gnueabi
 export CMAKE_PROGRAM_PATH=/usr/local/oecore-x86_64/sysroots/armv7vehf-neon-oe-linux-gnueabi/usr/bin/
 cmake -B build
-cmake --build build
-cmake --build build -t package
+cmake --build build -j -t package
 
 file="$(ls ./build/*.ipk | sort -V | tail -n1)"
 filename="$(basename $file)"
 sshpass -p "<password>" scp $file ceres@192.168.2.15:/home/ceres/
-sshpass -p "<password>" ssh root@192.168.2.15 << EOF
-  cd /home/ceres/
-  opkg install --force-overwrite $filename
-EOF
+sshpass -p "<password>" ssh root@192.168.2.15 opkg install --force-reinstall --force-overwrite /home/ceres/$filename
 ```
 
 You can debug your app by following along system logs with:

--- a/pages/wiki/creating-an-asteroid-app.md
+++ b/pages/wiki/creating-an-asteroid-app.md
@@ -209,6 +209,13 @@ If you want to disable screen locking for easier development you can enable the 
 mcetool -D on
 ```
 
+## Updating language translation files
+To update language translation files, and assuming you have all source files in `src` and translation files in `i18n` (which is short for "internationalization"), you can use this command to update the files.
+
+```
+lupdate-qt5 -no-obsolete src/* i18n/*.h -ts i18n/*.ts
+```
+
 # Building applications for the emulator
 The primary difference between the two versions of the SDK are that the real watches use an ARM processor, while the emulator uses a simulated x86 processor.  This allows the emulator to run much faster on computers based on the x86 architecture than if they had to emulate an ARM processor.
 


### PR DESCRIPTION
This fixes https://github.com/AsteroidOS/asteroid-settings/issues/80 by adding a language translation hint to the tips and tricks section of the "creating an AsteroidOS app" page.  It also enhances the command line build script in that same section.