### PR TITLE
narwhal: add new features and upgrade to 4 stars

### DIFF
--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -417,7 +417,7 @@
       "status":"supported",
       "maintainers": [ "dodoradio", "MagneFire" ],
       "contributors": [ "dodoradio", "MagneFire" ],
-      "stars":3,
+      "stars":4,
       "soc":"msm8909w",
       "kernelversion":"3.18",
       "androidversion":"oreo",
@@ -431,9 +431,9 @@
         { "name":"Microphone", "status":"good" },
         { "name":"Compass", "status":"good" },
         { "name":"USB", "status":"good" },
-        { "name":"WLAN", "status":"bad" },
+        { "name":"WLAN", "status":"good" },
         { "name":"Crown", "status":"good" },
-        { "name":"Hands", "status":"bad" }
+        { "name":"Hands", "status":"partial" }
       ]
     },
     {


### PR DESCRIPTION
Magnefire and I just got WLAN and hands working on narwhal. Hence:
- mark WLAN as 'working', recently fixed
- mark hands as 'partial', as hands-timesync now sets correct time and timezone to hands

since everything but hands is now green (and since hands are 'partial' rather than 'bad') it seems appropriate to bump narwhal to 4 stars. 