### PR TITLE
Correct soc value for wren

### DIFF
--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -812,7 +812,7 @@
       "maintainers": [ "eLtMosen" ],
       "contributors": [ "Lrs121", "dlandau", "eLtMosen", "MagneFire" ],
       "stars":4,
-      "soc":"msm8909w",
+      "soc":"msm8226",
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
       "features": [


### PR DESCRIPTION
Wren, just like its sibling sparrow, is a msm8226 device.