### PR TITLE
Koi: mark as experimental due to bricking issues

### DIFF
--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -328,7 +328,7 @@
         { "num":"WSD-F10", "name":"Casio Smart Outdoor Watch", "codename":"koi" },
         { "num":"WSD-F20", "name":"Casio Pro Trek Smart", "codename":"ayu" }
       ],
-      "status":"supported",
+      "status":"experimental",
       "maintainers": [ "dodoradio" ],
       "contributors": [ "dodoradio" ],
       "stars":3,

--- a/pages/watches/koi.md
+++ b/pages/watches/koi.md
@@ -6,6 +6,10 @@ section: install
 layout: aw-install
 installParts: [ install-prepare-adb, install-unlock-adb-round, install-select-method, install-full-adb-push-ext4, install-temp-flash-boot-to-recovery ]
 ---
+<div class="callout callout-warning">
+    <h4>WARNING: Bricking issues!</h4>
+    <p>These watches are known to brick themselves in various ways. Most bricks are recoverable, but occasionally the watch will seemingly corrupt its bootloader partition, which will cause it to get stuck in WearOS and bootloop. Proceed with extreme caution and consult <a href="https://matrix.to/#/#Asteroid:matrix.org">our matrix chat</a> before installing.</p>
+</div>
 <div class="callout callout-info">
     <h4>Model number and variants</h4>
     <p></p>


### PR DESCRIPTION
This marks koi as experimental and adds a warning about bricking issues 

my ayu just bricked itself, and I believe it is prudent to mark experimental until we figure out how fatal this is.
This is really really really disappointing. 