### PR TITLE
[Watches page] Add spacing to footer

### DIFF
--- a/templates/layouts/watches.hbs
+++ b/templates/layouts/watches.hbs
@@ -32,7 +32,8 @@
 
     {{> body }}
     </div>
-
+    {{!-- Spacing to footer --}}
+    <br><br><br>
     {{!-- Footer --}}
     {{> footer }}
 


### PR DESCRIPTION
- Add hardcoded line breaks as spacing to footer. Using a template has been investigated but no universal solution was found.

Signed-off-by: Timo Könnecke koennecke@mosushi.de