### PR TITLE
[Useful commands / Timezone setting] Remove warning

### DIFF
--- a/pages/wiki/useful-commands.md
+++ b/pages/wiki/useful-commands.md
@@ -112,8 +112,6 @@ systemctl --force reboot recovery # Restarts the watch in recovery mode
 
 Although we offer [synchronization clients]({{rel 'wiki/synchronization-clients'}}) for different platforms, it might still be useful to set the time zone or synchronise the date and time using standard Linux tools. The Linux folder `/usr/share/zoneinfo/` contains the naming scheme for your local time zone in `<continent>/<zone>` format.
 
-**Please Note** that setting a time zone will break time sync with the forementioned client apps.
-
 ```
 ssh root@192.168.2.15 "timedatectl set-timezone <continent>/<zone>" # e.g. Europe/Berlin
 ssh root@192.168.2.15 "date -s @`(date -u +"%s" )`"


### PR DESCRIPTION
- The issue of setting a timezone breaking time sync with AsteroidOSSync is now solved. As confirmed and tested by user cambionn and myself on 2 more watches.

Signed-off-by: Timo Könnecke koennecke@mosushi.de