### PR TITLE
[Fastboot combo] Add pike manual method

### DIFF
--- a/pages/wiki/useful-commands.md
+++ b/pages/wiki/useful-commands.md
@@ -138,6 +138,10 @@ Power down the watch. Keep holding both buttons during the boot process until th
 After the watch stops vibrating on startup, immediately touch the top/left & bottom/right of the screen and press the middle button while the manufacturer logo displays.
 
 &nbsp;
+#### Pike
+Power down the watch. Keep holding both buttons during the boot process, then select fastboot from the menu.
+
+&nbsp;
 #### Sawfish, Sawshark, Sturgeon
 Press and hold the power button when the manufacturer bootlogo appears, until the vibration finishes. Release the button and press it again quickly. The time frame for this method is short and might need several attempts. Some users report that spamming power button presses already during the vibration helps.
 


### PR DESCRIPTION
- Tested again, only pressing the front button also seems to work, but just holding both buttons went more reliable when rebooting via the power button.

Signed-off-by: Timo Könnecke koennecke@mosushi.de