### PR TITLE
[Building asteroidos] Move source hint from codeblock

### DIFF
--- a/pages/wiki/building-asteroidos.md
+++ b/pages/wiki/building-asteroidos.md
@@ -57,8 +57,10 @@ Install the prerequisites:
 
 This repository basically only contains a shell script that populates `src/` with OpenEmbedded and the appropriate Asteroid layers. Then, it setups the environment for a bitbake build. The following command will setup a build for `dory` (the LG G Watch) but you can also build an image for other watches by using the corresponding codename. (Codenames can be found on the <a href="{{rel 'watches'}}">Watches page</a>.)
 
+Important note: Like shown in the command below, the script must be sourced and not only ran.
+
 ```
-source ./prepare-build.sh dory # Be careful that this script must be sourced and not only ran
+source ./prepare-build.sh dory
 ```
 
 If the environment has been correctly setup, you should now be in the `build` subdirectory.


### PR DESCRIPTION
- The hint to not only run the prepare-build.sh but source it made the codeblock look confusing
- Double-click selection of the whole line contained the comment/hint.
- Moved over the codeblock
- Added important note to highlight it.

Signed-off-by: Timo Könnecke koennecke@mosushi.de