### PR TITLE
[Install pages] Add spacing to footer

### DIFF
--- a/templates/layouts/aw-install.hbs
+++ b/templates/layouts/aw-install.hbs
@@ -71,6 +71,9 @@
 
     </div>
 
+    {{!-- Spacing to footer --}}
+    <br><br>
+
     {{!-- Footer --}}
     {{> footer }}
 

--- a/templates/layouts/mtk-install.hbs
+++ b/templates/layouts/mtk-install.hbs
@@ -86,6 +86,9 @@
 
     </div>
 
+    {{!-- Spacing to footer --}}
+    <br><br>
+
     {{!-- Footer --}}
     {{> footer }}
 


### PR DESCRIPTION
- Add hardcoded line breaks as spacing to footer. 
- Using a template has been investigated but no universal solution was found. 
- Fixes https://github.com/AsteroidOS/asteroidos.org/issues/297

Signed-off-by: Timo Könnecke koennecke@mosushi.de