### PR TITLE
[Copy to clipboard button] Make function more universal 

### DIFF
--- a/templates/includes/install-full-adb-push-ext4.hbs
+++ b/templates/includes/install-full-adb-push-ext4.hbs
@@ -8,28 +8,28 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-lin-1">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-lin-1')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Boot your watch into fastboot bootloader mode, then flash the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-lin-2">fastboot flash boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-lin-2')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Then continue the boot process:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-lin-3">fastboot continue</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot continue</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-lin-3')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
         </div>
@@ -41,28 +41,28 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-win-1">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-win-1')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Boot your watch into fastboot bootloader mode, then flash the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-win-2">fastboot flash boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-win-2')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Then continue the boot process:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-win-3">fastboot continue</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot continue</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-win-3')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
         </div>

--- a/templates/includes/install-full.hbs
+++ b/templates/includes/install-full.hbs
@@ -6,28 +6,28 @@
           While your watch is in fastboot bootloader mode, flash the userdata partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-lin-1">fastboot flash userdata ~/Downloads/asteroid-image-{{deviceNames.[0]}}.{{#if simg}}simg{{else}}ext4{{/if}}</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash userdata ~/Downloads/asteroid-image-{{deviceNames.[0]}}.{{#if simg}}simg{{else}}ext4{{/if}}</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-lin-1')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           And the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-lin-2">fastboot flash boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-lin-2')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Then continue the boot process:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-lin-3">fastboot continue</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot continue</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-lin-3')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
         </div>
@@ -37,28 +37,28 @@
           While your watch is in fastboot bootloader mode, flash the userdata partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-win-1">fastboot flash userdata %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.{{#if simg}}simg{{else}}ext4{{/if}}</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash userdata %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.{{#if simg}}simg{{else}}ext4{{/if}}</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-win-1')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           And the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-win-2">fastboot flash boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-win-2')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Then continue the boot process:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-win-3">fastboot continue</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot continue</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-win-3')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
         </div>

--- a/templates/includes/install-prepare-adb.hbs
+++ b/templates/includes/install-prepare-adb.hbs
@@ -5,28 +5,28 @@
           <h4>Debian / Ubuntu</h4>
           <div class="install-code-wrapper" style="justify-content: center;">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre" style="border-radius: 4px;"><code id="apt">sudo apt install android-tools-adb <br>android-tools-fastboot</code></pre>
+              <pre class="install-code-pre" style="border-radius: 4px;"><code>sudo apt install android-tools-adb <br>android-tools-fastboot</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#apt')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           <h4>Fedora / OpenSUSE / CentOS</h4>
           <div class="install-code-wrapper" style="justify-content: center;">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code id="dnf">sudo dnf install android-tools</code></pre>
+              <pre class="install-code-pre"><code>sudo dnf install android-tools</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-             <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#dnf')" value="&#10697;"></input>
+             <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           <h4>Arch and derivatives</h4>
           <div class="install-code-wrapper" style="justify-content: center;">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code id="pacman">sudo pacman -Sy android-tools</code></pre>
+              <pre class="install-code-pre"><code>sudo pacman -Sy android-tools</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-             <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#pacman')" value="&#10697;"></input>
+             <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
         </div>

--- a/templates/includes/install-temp-encrypted.hbs
+++ b/templates/includes/install-temp-encrypted.hbs
@@ -3,10 +3,10 @@
           <br>While your watch is in bootloader mode, flash the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-lin-4">fastboot flash recovery ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-lin-4')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Then, use the top button on the watch to select "Recovery mode" and push the bottom button to boot into AsteroidOS.
@@ -14,10 +14,10 @@
           <br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-lin-5">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-lin-5')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
         </div>
@@ -27,10 +27,10 @@
           <br>While your watch is in bootloader mode, flash the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-win-4">fastboot flash recovery %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-win-4')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Then, use the top button on the watch to select "Recovery mode" and push the bottom button to boot into AsteroidOS.
@@ -38,10 +38,10 @@
           <br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-win-4">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-win-5')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
         </div>

--- a/templates/includes/install-temp-flash-boot-to-recovery.hbs
+++ b/templates/includes/install-temp-flash-boot-to-recovery.hbs
@@ -5,20 +5,20 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-lin-1">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-lin-1')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Everytime you want to boot into AsteroidOS, first boot your watch into fastboot bootloader mode.
           <br>Flash the boot image to the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-lin-2">fastboot flash recovery ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-lin-2')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Then boot to recovery:
@@ -36,20 +36,20 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-win-1">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-win-1')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Everytime you want to boot into AsteroidOS, first boot your watch into fastboot bootloader mode.
           <br>Flash the boot image to the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="full-win-2">fastboot flash recovery %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#full-win-2')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Then boot to recovery:

--- a/templates/includes/install-temp.hbs
+++ b/templates/includes/install-temp.hbs
@@ -5,28 +5,28 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-lin-1">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-lin-1')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Everytime you want to reboot into AsteroidOS from Wear OS, run:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-lin-2">adb reboot bootloader</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb reboot bootloader</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-lin-2')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Then, while the watch is in fastboot bootloader mode:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-lin-3">fastboot boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-lin-3')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
         </div>
@@ -38,28 +38,28 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-win-1">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-win-1')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Everytime you want to reboot into AsteroidOS from Wear OS, run:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-win-2">adb reboot bootloader</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb reboot bootloader</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-win-2')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
           Then, while the watch is in fastboot bootloader mode:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash" id="temp-win-3">fastboot boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
-              <input type="button" class="btn btn-primary clipboard-button" onclick="copyToClipboard('#temp-win-3')" value="&#10697;"></input>
+              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
         </div>

--- a/templates/includes/install-unlock-adb-beluga.hbs
+++ b/templates/includes/install-unlock-adb-beluga.hbs
@@ -46,20 +46,20 @@
   <a id="skip-adb-unlock"></a>
   <div class="install-code-wrapper">
     <div class="install-code-pre-wrapper">
-      <pre class="install-code-pre"><code class="bash" id="adbreboot">adb reboot bootloader</code></pre>
+      <pre class="install-code-pre"><code class="bash">adb reboot bootloader</code></pre>
     </div>
     <div class="clipboard-button-wrapper">
-      <input type="button"  class="btn btn-primary clipboard-button" onclick="copyToClipboard('#adbreboot')" value="&#10697;"></input>
+      <input type="button"  class="btn btn-primary clipboard-button" value="&#10697;"></input>
     </div>
   </div>
   <h3>1.3 Use fastboot to unlock the bootloader</h3>
   With your watch now in fastboot mode, enter this command in a terminal to start the unlock procedure.
   <div class="install-code-wrapper">
     <div class="install-code-pre-wrapper">
-      <pre class="install-code-pre"><code class="bash" id="fastbootunlock">fastboot oem unlock</code></pre>
+      <pre class="install-code-pre"><code class="bash">fastboot oem unlock</code></pre>
     </div>
     <div class="clipboard-button-wrapper">
-      <input type="button"  class="btn btn-primary clipboard-button" onclick="copyToClipboard('#fastbootunlock')" value="&#10697;"></input>
+      <input type="button"  class="btn btn-primary clipboard-button" value="&#10697;"></input>
     </div>
   </div>
   <h3>1.4 Follow the instructions on your watch's screen</h3><b>Please note again, this may void your warranty and will wipe your userdata.</b>
@@ -76,10 +76,10 @@
   <br>Enter the following ADB command in a terminal with your watch connected to USB.
   <div class="install-code-wrapper">
     <div class="install-code-pre-wrapper">
-      <pre class="install-code-pre"><code class="bash" id="rebootadb">adb reboot bootloader</code></pre>
+      <pre class="install-code-pre"><code class="bash">adb reboot bootloader</code></pre>
     </div>
     <div class="clipboard-button-wrapper">
-      <input type="button"  class="btn btn-primary clipboard-button" onclick="copyToClipboard('#rebootadb')" value="&#10697;"></input>
+      <input type="button"  class="btn btn-primary clipboard-button" value="&#10697;"></input>
     </div>
   </div>
   <div name="LinuxSsh" style="display: none">
@@ -88,10 +88,10 @@
     <br>Enter the following SSH command in a terminal with your watch connected to USB.
     <div class="install-code-wrapper">
       <div class="install-code-pre-wrapper">
-        <pre class="install-code-pre"><code class="bash" id="rebootssh">ssh ceres@192.168.2.15 "reboot bootloader"</code></pre>
+        <pre class="install-code-pre"><code class="bash">ssh ceres@192.168.2.15 "reboot bootloader"</code></pre>
       </div>
       <div class="clipboard-button-wrapper">
-        <input type="button"  class="btn btn-primary clipboard-button" onclick="copyToClipboard('#rebootssh')" value="&#10697;"></input>
+        <input type="button"  class="btn btn-primary clipboard-button" value="&#10697;"></input>
       </div>
     </div>
   </div>

--- a/templates/includes/install-unlock-adb-round.hbs
+++ b/templates/includes/install-unlock-adb-round.hbs
@@ -46,20 +46,20 @@
   <a id="skip-adb-unlock"></a>
   <div class="install-code-wrapper">
     <div class="install-code-pre-wrapper">
-      <pre class="install-code-pre"><code class="bash" id="adbreboot">adb reboot bootloader</code></pre>
+      <pre class="install-code-pre"><code class="bash">adb reboot bootloader</code></pre>
     </div>
     <div class="clipboard-button-wrapper">
-      <input type="button"  class="btn btn-primary clipboard-button" onclick="copyToClipboard('#adbreboot')" value="&#10697;"></input>
+      <input type="button"  class="btn btn-primary clipboard-button" value="&#10697;"></input>
     </div>
   </div>
   <h3>1.3 Use fastboot to unlock the bootloader</h3>
   With your watch now in fastboot mode, enter this command in a terminal to start the unlock procedure.
   <div class="install-code-wrapper">
     <div class="install-code-pre-wrapper">
-      <pre class="install-code-pre"><code class="bash" id="fastbootunlock">fastboot oem unlock</code></pre>
+      <pre class="install-code-pre"><code class="bash">fastboot oem unlock</code></pre>
     </div>
     <div class="clipboard-button-wrapper">
-      <input type="button"  class="btn btn-primary clipboard-button" onclick="copyToClipboard('#fastbootunlock')" value="&#10697;"></input>
+      <input type="button"  class="btn btn-primary clipboard-button" value="&#10697;"></input>
     </div>
   </div>
   <h3>1.4 Follow the instructions on your watch's screen</h3><b>Please note again, this may void your warranty and will wipe your userdata.</b>
@@ -76,10 +76,10 @@
   <br>Enter the following ADB command in a terminal with your watch connected to USB.
   <div class="install-code-wrapper">
     <div class="install-code-pre-wrapper">
-      <pre class="install-code-pre"><code class="bash" id="rebootadb">adb reboot bootloader</code></pre>
+      <pre class="install-code-pre"><code class="bash">adb reboot bootloader</code></pre>
     </div>
     <div class="clipboard-button-wrapper">
-      <input type="button"  class="btn btn-primary clipboard-button" onclick="copyToClipboard('#rebootadb')" value="&#10697;"></input>
+      <input type="button"  class="btn btn-primary clipboard-button" value="&#10697;"></input>
     </div>
   </div>
   <div name="LinuxSsh" style="display: none">
@@ -88,10 +88,10 @@
     <br>Enter the following SSH command in a terminal with your watch connected to USB.
     <div class="install-code-wrapper">
       <div class="install-code-pre-wrapper">
-        <pre class="install-code-pre"><code class="bash" id="rebootssh">ssh ceres@192.168.2.15 "reboot bootloader"</code></pre>
+        <pre class="install-code-pre"><code class="bash">ssh ceres@192.168.2.15 "reboot bootloader"</code></pre>
       </div>
       <div class="clipboard-button-wrapper">
-        <input type="button"  class="btn btn-primary clipboard-button" onclick="copyToClipboard('#rebootssh')" value="&#10697;"></input>
+        <input type="button"  class="btn btn-primary clipboard-button" value="&#10697;"></input>
       </div>
     </div>
   </div>

--- a/templates/includes/javascripts.hbs
+++ b/templates/includes/javascripts.hbs
@@ -37,18 +37,25 @@
 </script>
 
 <!-- Copy to clipboard button logic -->
-<script type="text/javascript">
-function copyToClipboard(element) {
-  var $temp = $("<input>");
-  $("body").append($temp);
-  $temp.val($(element).text()).select();
-  document.execCommand("copy");
-  $temp.remove();
-  $(document).click(function(event) {
-  if (event.target.value == "⧉") { event.target.value = "✔"; }
-  setTimeout( function() {
-        if (event.target.value == "✔") { event.target.value = "⧉"; }
-    }, 1000);
+<script>
+$(document).ready(function() {
+  $(".clipboard-button").click(function() {
+    var codeContent = $(this).closest(".install-code-wrapper").find("code").text();
+    copyToClipboard(codeContent);
+  });
 });
+
+function copyToClipboard(text) {
+  var temp = $("<input>");
+  $("body").append(temp);
+  temp.val(text).select();
+  document.execCommand("copy");
+  temp.remove();
+  $(document).click(function(event) {
+    if (event.target.value == "⧉") { event.target.value = "✔"; }
+    setTimeout( function() {
+      if (event.target.value == "✔") { event.target.value = "⧉"; }
+    }, 1000);
+  });
 }
 </script>


### PR DESCRIPTION
- Remove the necessity to target IDs but find the closest install-code-wrapper class, find the code block in that and copy its content to clipboard.
- Remove redundant IDs from install pages code blocks since the copy to clipboard function does not rely on those anymore.

Signed-off-by: Timo Könnecke koennecke@mosushi.de"