### PR TITLE
Improve android-tools installation instructions

### DIFF
--- a/styles/components/install-preparation-box.less
+++ b/styles/components/install-preparation-box.less
@@ -13,7 +13,7 @@
 
   border: none;
   border-radius: 4px;
-  min-height: 485px;
+  min-height: 510px;
   display: inline-block;
   width: 100%;
 

--- a/templates/includes/install-prepare-adb.hbs
+++ b/templates/includes/install-prepare-adb.hbs
@@ -2,7 +2,7 @@
         <h3>Install ADB & Fastboot</h3>
         <br>
         <div name="LinAdb" style="display: block">
-          <h4>Debian, Ubuntu, etc.</h4>
+          <h4>Debian / Ubuntu / Mint</h4>
           <div class="install-code-wrapper" style="justify-content: center;">
             <div class="install-code-pre-wrapper">
               <pre class="install-code-pre" style="border-radius: 4px;"><code>sudo apt install android-tools-adb <br>android-tools-fastboot</code></pre>
@@ -11,7 +11,7 @@
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
-          <h4>Fedora, CentOS, RHEL, etc.</h4>
+          <h4>Fedora / CentOS / RHEL</h4>
           <div class="install-code-wrapper" style="justify-content: center;">
             <div class="install-code-pre-wrapper">
               <pre class="install-code-pre"><code>sudo dnf install android-tools</code></pre>
@@ -20,7 +20,7 @@
              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
-          <h4>openSUSE, SLE</h4>
+          <h4>openSUSE / SLE</h4>
           <div class="install-code-wrapper" style="justify-content: center;">
             <div class="install-code-pre-wrapper">
               <pre class="install-code-pre"><code>sudo zypper install android-tools</code></pre>
@@ -29,7 +29,7 @@
              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
-          <h4>Arch, Manjaro, EndeavourOS, etc.</h4>
+          <h4>Arch / Manjaro / EndeavourOS</h4>
           <div class="install-code-wrapper" style="justify-content: center;">
             <div class="install-code-pre-wrapper">
               <pre class="install-code-pre"><code>sudo pacman -Sy android-tools</code></pre>

--- a/templates/includes/install-prepare-adb.hbs
+++ b/templates/includes/install-prepare-adb.hbs
@@ -2,7 +2,7 @@
         <h3>Install ADB & Fastboot</h3>
         <br>
         <div name="LinAdb" style="display: block">
-          <h4>Debian / Ubuntu</h4>
+          <h4>Debian, Ubuntu, etc.</h4>
           <div class="install-code-wrapper" style="justify-content: center;">
             <div class="install-code-pre-wrapper">
               <pre class="install-code-pre" style="border-radius: 4px;"><code>sudo apt install android-tools-adb <br>android-tools-fastboot</code></pre>
@@ -11,7 +11,7 @@
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
-          <h4>Fedora / OpenSUSE / CentOS</h4>
+          <h4>Fedora, CentOS, RHEL, etc.</h4>
           <div class="install-code-wrapper" style="justify-content: center;">
             <div class="install-code-pre-wrapper">
               <pre class="install-code-pre"><code>sudo dnf install android-tools</code></pre>
@@ -20,7 +20,16 @@
              <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
             </div>
           </div>
-          <h4>Arch and derivatives</h4>
+          <h4>openSUSE, SLE</h4>
+          <div class="install-code-wrapper" style="justify-content: center;">
+            <div class="install-code-pre-wrapper">
+              <pre class="install-code-pre"><code>sudo zypper install android-tools</code></pre>
+            </div>
+            <div class="clipboard-button-wrapper">
+             <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
+            </div>
+          </div>
+          <h4>Arch, Manjaro, EndeavourOS, etc.</h4>
           <div class="install-code-wrapper" style="justify-content: center;">
             <div class="install-code-pre-wrapper">
               <pre class="install-code-pre"><code>sudo pacman -Sy android-tools</code></pre>


### PR DESCRIPTION
These changes add/fix `android-tools` installation instructions for openSUSE & SUSE Linux Enterprise, and improves overall document structure for various Linux distributions.