### PR TITLE
[unlock] Warn to not relock

### DIFF
--- a/templates/includes/install-unlock-adb-beluga.hbs
+++ b/templates/includes/install-unlock-adb-beluga.hbs
@@ -5,8 +5,9 @@
     <h4>Note</h4>
     Unlocking the bootloader may void your warranty.
     <br>The unlock process will trigger a factory reset of Wear OS. Backup any data you do not want to loose.
+    <br>DO NOT relock the bootloader while having AsteroidOS installed.
   </div>
-  Installing AsteroidOS requires an unlocked bootloader.
+  Installing and booting AsteroidOS requires an unlocked bootloader.
   <br>Accessing the fastboot bootloader menu on your watch can be achieved either by using ADB in Wear OS or by manually stopping the boot process at the fastboot screen.
   <br>If you are familiar with the manual method to access the bootloader menu on your watch, you can <a href="#skip-adb-unlock">skip to step 1.3</a>. Those methods are explained on the <a href="https://asteroidos.org/wiki/useful-commands/#boot-to-fastboot-bootloader-menu">useful commands page</a>.
   To boot into fastboot menu from ADB within WearOS, follow steps 1.1 to 1.2.

--- a/templates/includes/install-unlock-adb-round.hbs
+++ b/templates/includes/install-unlock-adb-round.hbs
@@ -5,8 +5,9 @@
     <h4>Note</h4>
     Unlocking the bootloader may void your warranty.
     <br>The unlock process will trigger a factory reset of Wear OS. Backup any data you do not want to loose.
+    <br>DO NOT relock the bootloader while having AsteroidOS installed.
   </div>
-  Installing AsteroidOS requires an unlocked bootloader.
+  Installing and booting AsteroidOS requires an unlocked bootloader.
   <br>Accessing the fastboot bootloader menu on your watch can be achieved either by using ADB in Wear OS or by manually stopping the boot process at the fastboot screen.
   <br>If you are familiar with the manual method to access the bootloader menu on your watch, you can <a href="#skip-adb-unlock">skip to step 1.3</a>. Those methods are explained on the <a href="https://asteroidos.org/wiki/useful-commands/#boot-to-fastboot-bootloader-menu">useful commands page</a>.
   To boot into fastboot menu from ADB within WearOS, follow steps 1.1 to 1.2.


### PR DESCRIPTION
- Make clear in the info box to not relock the bootloader while AsteroidOS is installed
- Extend first sentence by <and booting> to make clear that AsteroidOS always needs an unlocked BL

Signed-off-by: Timo Könnecke koennecke@mosushi.de

![grafik](https://github.com/AsteroidOS/asteroidos.org/assets/15074193/6a96ad74-9165-4917-9255-a438d1081745)
