### PR TITLE
install: beluga: Add reboot step after pushing the .ext4 file.

### DIFF
--- a/templates/includes/install-temp-encrypted.hbs
+++ b/templates/includes/install-temp-encrypted.hbs
@@ -45,6 +45,17 @@
             </div>
           </div>
         </div>
+        Once pushed reboot to bootloader mode:
+        <div class="install-code-wrapper">
+          <div class="install-code-pre-wrapper">
+            <pre class="install-code-pre"><code class="bash">adb reboot bootloader</code></pre>
+          </div>
+          <div class="clipboard-button-wrapper">
+            <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
+          </div>
+        </div>
+        Again, use the top button on the watch to select "Recovery mode" and push the bottom button to boot into AsteroidOS.
+        <br>
         Everytime you want to reboot AsteroidOS:
         <br>
         While in recovery mode use the top button on the watch to select "Recovery mode" and push the bottom button to boot into the temporary image of AsteroidOS.


### PR DESCRIPTION
This adds a missing step after the the asteroidos.ext4 file is pushed. When the file is pushed one should reboot again to successfully boot into AsteroidOS.

This fixes https://github.com/AsteroidOS/asteroid/issues/255.

This is what the install page looks like after this change:
![image](https://github.com/AsteroidOS/asteroidos.org/assets/7857908/52626270-19f3-44a9-8fc9-968d5972d5b2)
