### PR TITLE
Add the release date of the watch

### DIFF
--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -16,6 +16,7 @@
       "soc":"msm8226",
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
+      "releasedate": 2014,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -45,6 +46,7 @@
       "soc":"msm8226",
       "kernelversion":"3.10",
       "androidversion":"lollipop",
+      "releasedate": 2015,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -77,6 +79,7 @@
       "soc":"msm8909w",
       "kernelversion":"4.9",
       "androidversion":"pie",
+      "releasedate": 2020,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -115,6 +118,7 @@
       "soc":"msm8909w",
       "kernelversion":"3.18",
       "androidversion":"pie",
+      "releasedate": 2018,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -151,6 +155,7 @@
       "soc":"msm8226",
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
+      "releasedate": 2014,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -193,6 +198,7 @@
       "soc":"msm8909w",
       "kernelversion":"3.18",
       "androidversion":"oreo",
+      "releasedate": 2018,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -279,6 +285,7 @@
       "soc":"msm8937",
       "kernelversion":"4.14",
       "androidversion":"pie",
+      "releasedate": 2021,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -346,6 +353,7 @@
       "soc":"exynos3250",
       "kernelversion":"3.18",
       "androidversion":"oreo",
+      "releasedate": 2016,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -377,6 +385,7 @@
       "soc":"msm8226",
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
+      "releasedate": 2014,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -407,6 +416,7 @@
       "soc":"omap",
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
+      "releasedate": 2014,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -437,6 +447,7 @@
       "soc":"mediatek",
       "kernelversion":"4.4",
       "androidversion":"oreo",
+      "releasedate": 2017,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -468,6 +479,7 @@
       "soc":"msm8909w",
       "kernelversion":"3.18",
       "androidversion":"oreo",
+      "releasedate": 2018,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -499,6 +511,7 @@
       "soc":"mediatek",
       "kernelversion":"3.10",
       "androidversion":"oreo",
+      "releasedate": 2016,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -530,6 +543,7 @@
       "soc":"msm8909w",
       "kernelversion":"3.18",
       "androidversion":"oreo",
+      "releasedate": 2018,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -565,6 +579,7 @@
       "soc":"msm8909w",
       "kernelversion":"3.18",
       "androidversion":"nougat",
+      "releasedate": 2017,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -599,6 +614,7 @@
       "soc":"msm8909w",
       "kernelversion":"3.18",
       "androidversion":"oreo",
+      "releasedate": 2018,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -634,6 +650,7 @@
       "soc":"msm8226",
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
+      "releasedate": 2015,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -666,6 +683,7 @@
       "soc":"msm8226",
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
+      "releasedate": 2015,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -695,6 +713,7 @@
       "soc":"msm8226",
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
+      "releasedate": 2014,
       "features": [
         { "name":"Display", "status":"partial" },
         { "name":"Touch", "status":"good" },
@@ -723,6 +742,7 @@
       "soc":"msm8226",
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
+      "releasedate": 2015,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -753,6 +773,7 @@
       "soc":"msm8909w",
       "kernelversion":"3.18",
       "androidversion":"marshmallow",
+      "releasedate": 2016,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -781,6 +802,7 @@
       "soc":"bcm",
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
+      "releasedate": 2014,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -813,6 +835,7 @@
       "soc":"msm8909w",
       "kernelversion":"3.18",
       "androidversion":"oreo",
+      "releasedate": 2019,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },
@@ -843,6 +866,7 @@
       "soc":"msm8226",
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
+      "releasedate": 2015,
       "features": [
         { "name":"Display", "status":"good" },
         { "name":"Touch", "status":"good" },

--- a/templates/includes/installbox.hbs
+++ b/templates/includes/installbox.hbs
@@ -1,7 +1,10 @@
 {{#with this}}
-  <a href="{{#if reference}}{{reference}}{{else}}{{name}}{{/if}}"><div class="install-box">
+<a href="{{#if reference}}{{reference}}{{else}}{{name}}{{/if}}">
+  <div class="install-box">
     <img src="../public/img/{{name}}.png" class="install-watch-img"><br>
     <b>{{models}}</b><br>({{name}}{{#if othernames}}{{#othernames}}, {{.}}{{/othernames}}{{/if}})<br>
-    <i>Support: {{#starString stars 5}}{{/starString}}</i>
-  </div></a>
+    <i>Support: {{#starString stars 5}}{{/starString}}</i><br>
+    {{#if releasedate}} <i>Release date: <b>{{releasedate}}</b></i>{{/if}}
+  </div>
+</a>
 {{/with}}


### PR DESCRIPTION
I agree with this [issue](https://github.com/AsteroidOS/asteroidos.org/issues/410) but I think it would be convenient to know which ones are the most recent without opening the individual watch page.
For some watches I did not add the date because they do not correspond to a single watch