### PR TITLE
Add specific version for alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:20231219
 LABEL maintainer="Ed Beroset <beroset@ieee.org>"
 WORKDIR /tmp/
 RUN apk --no-cache add nodejs git npm lighttpd


### PR DESCRIPTION
This specifies a particular version for the Alpine image rather than using "latest".  This is better both because it causes the created image to be repeatable (that is, no matter when we build, it's always the same result) and also gets around a bug described here: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/58154