### PR TITLE
rss: Only generate feed when assembling main page.

### DIFF
--- a/templates/_plugins/rss.js
+++ b/templates/_plugins/rss.js
@@ -17,6 +17,10 @@ module.exports = function (config, callback) {
 
   var pages = options.pages; // Define an array all of page data.
   var page = options.page; // Define a single page's data object.
+  if (page.data.slug != 'index') {
+    callback();
+    return;
+  }
 
   // Skip over the plugin if it isn't defined in the options.
   if (!_.isUndefined(config)) {


### PR DESCRIPTION
Previously the RSS feed was generated for every assembled page resulting in a `feed.xml` in every sub-directory.
Moreover it also resulted in wrong links to the news pages (omitting `news` in the url).