### PR TITLE
Make DO NOT relock warning more obvious

### DIFF
--- a/styles/components/callout.less
+++ b/styles/components/callout.less
@@ -42,10 +42,10 @@
 }
 
 .callout-danger {
-  background-color: #fdf7f7;
-  border-color: #eed3d7;
+  background-color: #FCEDF0;
+  border-color: #E03E59;
   h4 {
-    color: #b94a48;
+    color: #E03E59;
   }
 }
 

--- a/templates/includes/install-unlock-adb-beluga.hbs
+++ b/templates/includes/install-unlock-adb-beluga.hbs
@@ -5,7 +5,10 @@
     <h4>Note</h4>
     Unlocking the bootloader may void your warranty.
     <br>The unlock process will trigger a factory reset of Wear OS. Backup any data you do not want to loose.
-    <br>DO NOT relock the bootloader while having AsteroidOS installed.
+  </div>
+  <div class="callout callout-danger">
+    <h4>Warning</h4>
+    DO NOT relock the bootloader while having AsteroidOS installed. This puts the device into a non-recoverable state.
   </div>
   Installing and booting AsteroidOS requires an unlocked bootloader.
   <br>Accessing the fastboot bootloader menu on your watch can be achieved either by using ADB in Wear OS or by manually stopping the boot process at the fastboot screen.

--- a/templates/includes/install-unlock-adb-round.hbs
+++ b/templates/includes/install-unlock-adb-round.hbs
@@ -5,7 +5,10 @@
     <h4>Note</h4>
     Unlocking the bootloader may void your warranty.
     <br>The unlock process will trigger a factory reset of Wear OS. Backup any data you do not want to loose.
-    <br>DO NOT relock the bootloader while having AsteroidOS installed.
+  </div>
+  <div class="callout callout-danger">
+    <h4>Warning</h4>
+    DO NOT relock the bootloader while having AsteroidOS installed. This puts the device into a non-recoverable state.
   </div>
   Installing and booting AsteroidOS requires an unlocked bootloader.
   <br>Accessing the fastboot bootloader menu on your watch can be achieved either by using ADB in Wear OS or by manually stopping the boot process at the fastboot screen.


### PR DESCRIPTION
As hinted by NickTheNeko on Matrix, the only recently added DO NOT relock warning was not obvious since hidden in the Notes box.

- Move the relock warning to its own callout-danger box
- Adjust the callout-danger color scheme to be more intense red.

After change:
![grafik](https://github.com/AsteroidOS/asteroidos.org/assets/15074193/933e1874-9f1c-4f1e-9f4a-af5e2315fb6b)
