### PR TITLE
[catfish] Add info notes for GPS and LCD support

### DIFF
--- a/pages/watches/catfish.md
+++ b/pages/watches/catfish.md
@@ -7,6 +7,6 @@ layout: aw-install
 ---
 <div class="callout callout-info">
     <p>Hardware support notes:</p>
-    <p>Dual-Display support<br> Is marked partial due to incomplete support. The secondary LCD works on all models and shows the time and steps when enabled. However, enabling the step counter and the timepiece mode is currently not available through the user interface.</p>
+    <p>Dual-Display support<br> Is marked partial due to incomplete support. The secondary LCD works on all models and shows the time and steps when enabled from cli. However, enabling the step counter and the timepiece mode is currently not available through the user interface.</p>
     <p>GPS support<br> Is marked partial because GPS is integrated into the modem in the catshark model, which is currently not supported. GPS works without issues on the catfish and catfish_ext models.</p>
 </div>

--- a/pages/watches/catfish.md
+++ b/pages/watches/catfish.md
@@ -5,3 +5,8 @@ label: catfish/catfish_ext/catshark
 section: install
 layout: aw-install
 ---
+<div class="callout callout-info">
+    <p>Hardware support notes:</p>
+    <p>Dual-Display support<br> Is marked partial due to incomplete support. The secondary LCD works on all models and shows the time and steps when enabled. However, enabling the step counter and the timepiece mode is currently not available through the user interface.</p>
+    <p>GPS support<br> Is marked partial because GPS is integrated into the modem in the catshark model, which is currently not supported. GPS works without issues on the catfish and catfish_ext models.</p>
+</div>


### PR DESCRIPTION
As noted by hacker420 in the matrix chat, an explanation to why GPS and LCD are listed as partially supported might be good for clarity.

After the change:
![grafik](https://github.com/AsteroidOS/asteroidos.org/assets/15074193/aa4d31df-f000-4a87-ac48-36ada2d0dd9f)
