### PR TITLE
templates: Rename rootfs image to new Yocto scarthgap based format

### DIFF
--- a/templates/includes/install-full-adb-push-ext4.hbs
+++ b/templates/includes/install-full-adb-push-ext4.hbs
@@ -8,7 +8,7 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.rootfs.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -41,7 +41,7 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.rootfs.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-full.hbs
+++ b/templates/includes/install-full.hbs
@@ -6,7 +6,7 @@
           While your watch is in fastboot bootloader mode, flash the userdata partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash userdata ~/Downloads/asteroid-image-{{deviceNames.[0]}}.{{#if simg}}simg{{else}}ext4{{/if}}</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash userdata ~/Downloads/asteroid-image-{{deviceNames.[0]}}.rootfs.{{#if simg}}simg{{else}}ext4{{/if}}</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -37,7 +37,7 @@
           While your watch is in fastboot bootloader mode, flash the userdata partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash userdata %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.{{#if simg}}simg{{else}}ext4{{/if}}</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash userdata %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.rootfs.{{#if simg}}simg{{else}}ext4{{/if}}</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-prepare-downloads.hbs
+++ b/templates/includes/install-prepare-downloads.hbs
@@ -3,8 +3,8 @@
       <div class="install-preparation-box">
         <h3>Download AsteroidOS for {{.}}</h3>
         Store the files in your "Downloads" folder so the later commands work<br>
-        <a class="btn btn-primary" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.ext4" role="button">asteroid-image-{{.}}.ext4</a>
-        <a class="btn btn-primary" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.simg" role="button">asteroid-image-{{.}}.simg</a>
+        <a class="btn btn-primary" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.rootfs.ext4" role="button">asteroid-image-{{.}}.rootfs.ext4</a>
+        <a class="btn btn-primary" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.rootfs.simg" role="button">asteroid-image-{{.}}.rootfs.simg</a>
         <a class="btn btn-primary" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/zImage-dtb-{{.}}.fastboot" role="button">zImage-dtb-{{.}}.fastboot</a>
         <br><br><img src="{{../assets}}/img/{{.}}.png" class="install-preparation-img"><br>
       </div>
@@ -14,7 +14,7 @@
       <div class="install-preparation-box">
         <h3>Download AsteroidOS for {{.}}</h3>
         Store the files in your "Downloads" folder so the later commands work<br>
-        <a class="btn btn-primary" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.ext4" role="button">asteroid-image-{{.}}.ext4</a>
+        <a class="btn btn-primary" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.rootfs.ext4" role="button">asteroid-image-{{.}}.rootfs.ext4</a>
         <a class="btn btn-primary" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/zImage-dtb-{{.}}.fastboot" role="button">zImage-dtb-{{.}}.fastboot</a>
         <br><br><img src="{{../assets}}/img/{{.}}.png" class="install-preparation-img"><br>
       </div>

--- a/templates/includes/install-temp-encrypted.hbs
+++ b/templates/includes/install-temp-encrypted.hbs
@@ -14,7 +14,7 @@
           <br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.rootfs.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -38,7 +38,7 @@
           <br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.rootfs.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-temp-flash-boot-to-recovery.hbs
+++ b/templates/includes/install-temp-flash-boot-to-recovery.hbs
@@ -5,7 +5,7 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.rootfs.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -36,7 +36,7 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.rootfs.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-temp.hbs
+++ b/templates/includes/install-temp.hbs
@@ -5,7 +5,7 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p ~/Downloads/asteroid-image-{{deviceNames.[0]}}.rootfs.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -38,7 +38,7 @@
           <br><br>Push AsteroidOS to the internal sdcard:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.ext4 /sdcard/asteroidos.ext4</code></pre>
+              <pre class="install-code-pre"><code class="bash">adb push -p %systemdrive%%homepath%\Downloads\asteroid-image-{{deviceNames.[0]}}.rootfs.ext4 /sdcard/asteroidos.ext4</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/layouts/mtk-install.hbs
+++ b/templates/layouts/mtk-install.hbs
@@ -42,7 +42,7 @@
         <h3>Download AsteroidOS for {{.}}</h3>
         Store the files in your "Downloads" folder so the later commands work<br><br>
         <p>
-          <a class="btn btn-primary" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.ext4" role="button">asteroid-image-{{.}}.ext4</a>
+          <a class="btn btn-primary" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.rootfs.ext4" role="button">asteroid-image-{{.}}.rootfs.ext4</a>
           <a class="btn btn-primary" href="https://release.asteroidos.org/nightlies/{{.}}/zImage-dtb-{{.}}.fastboot" role="button">zImage-dtb-{{.}}.fastboot</a>
         </p>
         <a class="btn btn-primary" href="https://release.asteroidos.org/nightlies/{{.}}/MT6580_AsteroidOS_scatter-{{.}}.txt" role="button">MT6580_AsteroidOS_scatter-{{.}}.txt</a>


### PR DESCRIPTION
Renames asteroid-image-<device>.ext4 to asteroid-image-<device>.rootfs.ext4

Currently a build of our current Yocto scarthgap is running. I'll test this PR once the build is finished and merge once confirmed working correctly.