### PR TITLE
watches: Use sparse image instructions for pike

### DIFF
--- a/pages/watches/pike.md
+++ b/pages/watches/pike.md
@@ -1,5 +1,6 @@
 ---
 title: Polar M600
 deviceNames: [ pike ]
+simg: true
 layout: aw-install
 ---


### PR DESCRIPTION
This is a result of the findings in https://github.com/AsteroidOS/meta-smartwatch/pull/238