### PR TITLE
Use css animation, not obsolete -webkit-animation

### DIFF
--- a/styles/components/about-rows.less
+++ b/styles/components/about-rows.less
@@ -102,22 +102,22 @@
 
 .slide-wrapper {
   width: 5000px; //slide width * amount of shots
-  -webkit-animation: slide 35s ease infinite;
+  animation: slide 35s ease infinite alternate;
 
   //From < 990px (sm) on
   @media (max-width: 991px) {
     width: 4875px;
-    -webkit-animation: slide 30s ease infinite;
+    animation: slide 30s ease infinite alternate;
   }
   //From < 768px (sm) on
   @media (max-width: 767px) {
     width: 4500px;
-    -webkit-animation: slide 30s ease infinite;
+    animation: slide 30s ease infinite alternate;
   }
     //From < 520px (sm) on
   @media (max-width: 519px) {
     width: 4125px;
-    -webkit-animation: slide 30s ease infinite;
+    animation: slide 30s ease infinite alternate;
   }
 }
 


### PR DESCRIPTION
This updates the slide show animation (for the screen images at the top of the main page) to use animation which is now supported by all browsers, rather than the deprecated -webkit-animation.

It also changes the animation so that it goes forward and then reverses rather than its current behavior of resetting quickly to the beginning.