### PR TITLE
Add more prominent warning about making a backup

### DIFF
--- a/templates/includes/install-select-method.hbs
+++ b/templates/includes/install-select-method.hbs
@@ -15,4 +15,8 @@
         </div>
         Replace WearOS definitively by flashing the system and boot image.
         <br>The real installation provides the best experience, but it is advised to make a <a href="https://asteroidos.org/wiki/backup/">backup of your previous OS</a> first.
+      <div class="callout callout-danger">
+        <h4>Warning</h4>
+        If you do not make a backup BEFORE doing a real installation, it may not be possible to restore your previous OS!
+      </div>
         <br>We highly recommend to first test if AsteroidOS meets the requirements of your usecase by performing the non invasive temporary installation before permanently replacing your previous OS.


### PR DESCRIPTION
Several people recently have asked on Matrix for help restoring their original OS but had failed to make a backup as mentioned on the installation instructions.  This adds a much more prominent warning and mentions the consequence of not backing up.  This fixes #447.