### PR TITLE
mooneye: Add permanent install

### DIFF
--- a/pages/watches/mooneye.md
+++ b/pages/watches/mooneye.md
@@ -1,6 +1,6 @@
 ---
 title: TicWatch E & S
 deviceNames: [ mooneye ]
+simg: true
 layout: aw-install
-installParts: [ install-prepare-adb, install-unlock-adb-round, install-temponly ]
 ---


### PR DESCRIPTION
This relies on the use of sparse images.

Currently draft as the sparse image won't be built until the end of next week (due to this change: https://github.com/AsteroidOS/meta-smartwatch/commit/26df07303fd30a13dac145c9e2faedd2d94afdb2).