### PR TITLE
Add USB info box to beluga install

### DIFF
--- a/pages/watches/beluga.md
+++ b/pages/watches/beluga.md
@@ -12,4 +12,7 @@ installParts: [ install-prepare-adb, install-unlock-adb-beluga, install-select-m
 <div class="callout callout-info">
     <p>Make sure your OPPO Watch has been updated to a current firmware version via the WearOS update feature. There have been reports of problems with the installation instructions described below if the firmware version is too old.</p>
 </div>
-
+<div class="callout callout-info">
+    <h4>USB Info</h4>
+    <p>USB support is marked "partial" due to non working SSH connection. Only ADB connection is availble.</p>
+</div>


### PR DESCRIPTION
explaining the partial usb support and missing SSH connection.