### PR TITLE
minnow: Update current state of features

### DIFF
--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -408,7 +408,7 @@
       "kernelversion":"3.10",
       "androidversion":"marshmallow",
       "features": [
-        { "name":"Display", "status":"good" },
+        { "name":"Display", "status":"bad" },
         { "name":"Touch", "status":"good" },
         { "name":"Bluetooth", "status":"bad" },
         { "name":"Haptics", "status":"good" },
@@ -416,7 +416,7 @@
         { "name":"Light Sensor", "status":"good" },
         { "name":"Always-on-Display", "status":"bad" },
         { "name":"Microphone", "status":"good" },
-        { "name":"USB", "status":"good" },
+        { "name":"USB", "status":"bad" },
         { "name":"WLAN", "status":"good" }
       ]
     },


### PR DESCRIPTION
Since Yocto Mickledore `minnow` is performing even worse, now it's remains stuck at the bootlogo and USB is also broken.