### PR TITLE
Add link to triggerfish page on wiki

### DIFF
--- a/pages/watches-support.json
+++ b/pages/watches-support.json
@@ -862,6 +862,7 @@
     },
     {
       "name":"triggerfish",
+      "wiki": "https://wiki.asteroidos.org/index.php/Triggerfish",
       "models": [
         "Fossil Gen 5"
       ],


### PR DESCRIPTION
This, combined with additions already made to the wiki, fix #471 with working links to both triggerfish (new) and rinato (existing).