### PR TITLE
Enlarge height of banner to allow space for shadow

### DIFF
--- a/styles/components/slideshow-stepper.less
+++ b/styles/components/slideshow-stepper.less
@@ -10,7 +10,7 @@
   left: 0;
   right: 0;
   text-align: center;
-  height: 225px;
+  height: 230px;
   margin: 7VH 0 0 0;
 
   //From < 991px (sm) on


### PR DESCRIPTION
This elarges the height of the banner by 5px to allow the rotating screenshot dropshadows not to be cut off at the bottom.