### PR TITLE
[hoki] add note about skipping the QR code screen in Wear OS

### DIFF
--- a/pages/watches/hoki.md
+++ b/pages/watches/hoki.md
@@ -5,3 +5,7 @@ section: install
 layout: aw-install
 installParts: [ install-prepare-adb, install-unlock-adb-round, install-select-method, install-full, install-temp-encrypted ]
 ---
+<div class="callout callout-info">
+    <h4>WearOS First Boot</h4>
+    <p>Some variants (e.g. Skagen Falster 6) may boot into a QR code screen linking to a companion app. To access the settings and enable USB debugging, long-press the crown button.</p>
+</div>


### PR DESCRIPTION
I just got a hoki, and thought I was blocked, because I do not have a android phone with playstore. After factory reset, the watch shows a QR code on screen that links to the Skagen Watch app.

Long pressing one of the buttons (I believe it was the middle one, with the crown) opens another menu where you can go into settings to enable USB debugging.

I've already overwritten WearOS so can't provide a photo of the screen or menu.