### PR TITLE
Add support for modern Android boot images

### DIFF
--- a/templates/includes/install-full-adb-push-ext4.hbs
+++ b/templates/includes/install-full-adb-push-ext4.hbs
@@ -17,7 +17,7 @@
           Boot your watch into fastboot bootloader mode, then flash the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot ~/Downloads/boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -50,7 +50,7 @@
           Boot your watch into fastboot bootloader mode, then flash the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot %systemdrive%%homepath%\Downloads\boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-full-adb-push-ext4.hbs
+++ b/templates/includes/install-full-adb-push-ext4.hbs
@@ -17,7 +17,7 @@
           Boot your watch into fastboot bootloader mode, then flash the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot ~/Downloads/asteroid-{{deviceNames.[0]}}-boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -50,7 +50,7 @@
           Boot your watch into fastboot bootloader mode, then flash the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot %systemdrive%%homepath%\Downloads\asteroid-{{deviceNames.[0]}}-boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-full.hbs
+++ b/templates/includes/install-full.hbs
@@ -15,7 +15,7 @@
           And the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot ~/Downloads/boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -46,7 +46,7 @@
           And the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot %systemdrive%%homepath%\Downloads\boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-full.hbs
+++ b/templates/includes/install-full.hbs
@@ -15,7 +15,7 @@
           And the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot ~/Downloads/asteroid-{{deviceNames.[0]}}-boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -46,7 +46,7 @@
           And the boot partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash boot %systemdrive%%homepath%\Downloads\asteroid-{{deviceNames.[0]}}-boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-heimdall.hbs
+++ b/templates/includes/install-heimdall.hbs
@@ -5,7 +5,7 @@
         While your watch is in download mode, flash the userdata and boot partition:
         <div class="install-code-wrapper">
           <div class="install-code-pre-wrapper">
-            <pre class="install-code-pre"><code class="bash">heimdall flash --BOOT ~/Downloads/zImage-{{deviceNames.[0]}}.bin --USER ~/Downloads/asteroid-image-{{deviceNames.[0]}}.rootfs.ext4</code></pre>
+            <pre class="install-code-pre"><code class="bash">heimdall flash --BOOT ~/Downloads/boot.img --USER ~/Downloads/asteroid-image-{{deviceNames.[0]}}.rootfs.ext4</code></pre>
           </div>
           <div class="clipboard-button-wrapper">
             <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-heimdall.hbs
+++ b/templates/includes/install-heimdall.hbs
@@ -5,7 +5,7 @@
         While your watch is in download mode, flash the userdata and boot partition:
         <div class="install-code-wrapper">
           <div class="install-code-pre-wrapper">
-            <pre class="install-code-pre"><code class="bash">heimdall flash --BOOT ~/Downloads/zImage-{{deviceNames.[0]}}.bin --USER ~/Downloads/asteroid-image-{{deviceNames.[0]}}.rootfs.ext4</code></pre>
+            <pre class="install-code-pre"><code class="bash">heimdall flash --BOOT ~/Downloads/asteroid-{{deviceNames.[0]}}-boot.img --USER ~/Downloads/asteroid-image-{{deviceNames.[0]}}.rootfs.ext4</code></pre>
           </div>
           <div class="clipboard-button-wrapper">
             <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-prepare-downloads.hbs
+++ b/templates/includes/install-prepare-downloads.hbs
@@ -6,10 +6,15 @@
         {{#if ../simg}}
         <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.rootfs.simg" role="button">asteroid-image-{{.}}.rootfs.simg</a>
         {{/if}}
-        {{#if ../heimdall}}
-        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/zImage-dtb-{{.}}.bin" role="button">zImage-dtb-{{.}}.bin</a>
-        {{else}}
-        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/zImage-dtb-{{.}}.fastboot" role="button">zImage-dtb-{{.}}.fastboot</a>
+        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/boot.img" role="button">boot.img</a>
+        {{#if ../vendor_boot}}
+        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/vendor_boot.img" role="button">vendor_boot.img</a>
+        {{/if}}
+        {{#if ../init_boot}}
+        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/init_boot.img" role="button">init_boot.img</a>
+        {{/if}}
+        {{#if ../dtbo}}
+        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/dtbo.img" role="button">dtbo.img</a>
         {{/if}}
         <br><br><img src="{{../assets}}/img/{{.}}.png" class="install-preparation-img"><br>
       </div>

--- a/templates/includes/install-prepare-downloads.hbs
+++ b/templates/includes/install-prepare-downloads.hbs
@@ -6,10 +6,15 @@
         {{#if ../simg}}
         <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.rootfs.simg" role="button">asteroid-image-{{.}}.rootfs.simg</a>
         {{/if}}
-        {{#if ../heimdall}}
-        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/zImage-dtb-{{.}}.bin" role="button">zImage-dtb-{{.}}.bin</a>
-        {{else}}
-        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/zImage-dtb-{{.}}.fastboot" role="button">zImage-dtb-{{.}}.fastboot</a>
+        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-{{.}}-boot.img" role="button">boot.img</a>
+        {{#if ../vendor_boot}}
+        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-{{.}}-vendor_boot.img" role="button">vendor_boot.img</a>
+        {{/if}}
+        {{#if ../init_boot}}
+        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-{{.}}-init_boot.img" role="button">init_boot.img</a>
+        {{/if}}
+        {{#if ../dtbo}}
+        <a class="btn btn-primary download-link" style="margin-top: 10px;" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-{{.}}-dtbo.img" role="button">dtbo.img</a>
         {{/if}}
         <br><br><img src="{{../assets}}/img/{{.}}.png" class="install-preparation-img"><br>
       </div>

--- a/templates/includes/install-temp-encrypted.hbs
+++ b/templates/includes/install-temp-encrypted.hbs
@@ -3,7 +3,7 @@
           <br>While your watch is in bootloader mode, flash the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash recovery ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery ~/Downloads/boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -27,7 +27,7 @@
           <br>While your watch is in bootloader mode, flash the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash recovery %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery %systemdrive%%homepath%\Downloads\boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-temp-encrypted.hbs
+++ b/templates/includes/install-temp-encrypted.hbs
@@ -3,7 +3,7 @@
           <br>While your watch is in bootloader mode, flash the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash recovery ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery ~/Downloads/asteroid-{{deviceNames.[0]}}-boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -27,7 +27,7 @@
           <br>While your watch is in bootloader mode, flash the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash recovery %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery %systemdrive%%homepath%\Downloads\asteroid-{{deviceNames.[0]}}-boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-temp-flash-boot-to-recovery.hbs
+++ b/templates/includes/install-temp-flash-boot-to-recovery.hbs
@@ -15,7 +15,7 @@
           <br>Flash the boot image to the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash recovery ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery ~/Downloads/boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -46,7 +46,7 @@
           <br>Flash the boot image to the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash recovery %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery %systemdrive%%homepath%\Downloads\boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-temp-flash-boot-to-recovery.hbs
+++ b/templates/includes/install-temp-flash-boot-to-recovery.hbs
@@ -15,7 +15,7 @@
           <br>Flash the boot image to the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash recovery ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery ~/Downloads/asteroid-{{deviceNames.[0]}}-boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -46,7 +46,7 @@
           <br>Flash the boot image to the recovery partition:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot flash recovery %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot flash recovery %systemdrive%%homepath%\Downloads\asteroid-{{deviceNames.[0]}}-boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-temp.hbs
+++ b/templates/includes/install-temp.hbs
@@ -23,7 +23,7 @@
           Then, while the watch is in fastboot bootloader mode:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot boot ~/Downloads/boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -56,7 +56,7 @@
           Then, while the watch is in fastboot bootloader mode:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot boot %systemdrive%%homepath%\Downloads\boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/includes/install-temp.hbs
+++ b/templates/includes/install-temp.hbs
@@ -23,7 +23,7 @@
           Then, while the watch is in fastboot bootloader mode:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot boot ~/Downloads/zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot boot ~/Downloads/asteroid-{{deviceNames.[0]}}-boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>
@@ -56,7 +56,7 @@
           Then, while the watch is in fastboot bootloader mode:
           <div class="install-code-wrapper">
             <div class="install-code-pre-wrapper">
-              <pre class="install-code-pre"><code class="bash">fastboot boot %systemdrive%%homepath%\Downloads\zImage-dtb-{{deviceNames.[0]}}.fastboot</code></pre>
+              <pre class="install-code-pre"><code class="bash">fastboot boot %systemdrive%%homepath%\Downloads\asteroid-{{deviceNames.[0]}}-boot.img</code></pre>
             </div>
             <div class="clipboard-button-wrapper">
               <input type="button" class="btn btn-primary clipboard-button" value="&#10697;"></input>

--- a/templates/layouts/mtk-install.hbs
+++ b/templates/layouts/mtk-install.hbs
@@ -54,7 +54,7 @@
         Store the files in your "Downloads" folder so the later commands work<br><br>
         <p>
           <a class="btn btn-primary  download-link" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.rootfs.ext4" role="button">asteroid-image-{{.}}.rootfs.ext4</a>
-          <a class="btn btn-primary download-link" href="https://release.asteroidos.org/nightlies/{{.}}/zImage-dtb-{{.}}.fastboot" role="button">zImage-dtb-{{.}}.fastboot</a>
+          <a class="btn btn-primary download-link" href="https://release.asteroidos.org/nightlies/boot.img" role="button">boot.img</a>
         </p>
         <a class="btn btn-primary download-link" href="https://release.asteroidos.org/nightlies/{{.}}/MT6580_AsteroidOS_scatter-{{.}}.txt" role="button">MT6580_AsteroidOS_scatter-{{.}}.txt</a>
         <a class="btn btn-primary download-link" href="https://release.asteroidos.org/nightlies/{{.}}/logo.bin" role="button">logo.bin</a>

--- a/templates/layouts/mtk-install.hbs
+++ b/templates/layouts/mtk-install.hbs
@@ -54,7 +54,7 @@
         Store the files in your "Downloads" folder so the later commands work<br><br>
         <p>
           <a class="btn btn-primary  download-link" href="https://release.asteroidos.org/nightlies/{{.}}/asteroid-image-{{.}}.rootfs.ext4" role="button">asteroid-image-{{.}}.rootfs.ext4</a>
-          <a class="btn btn-primary download-link" href="https://release.asteroidos.org/nightlies/{{.}}/zImage-dtb-{{.}}.fastboot" role="button">zImage-dtb-{{.}}.fastboot</a>
+          <a class="btn btn-primary download-link" href="https://release.asteroidos.org/nightlies/asteroid-{{.}}-boot.img" role="button">boot.img</a>
         </p>
         <a class="btn btn-primary download-link" href="https://release.asteroidos.org/nightlies/{{.}}/MT6580_AsteroidOS_scatter-{{.}}.txt" role="button">MT6580_AsteroidOS_scatter-{{.}}.txt</a>
         <a class="btn btn-primary download-link" href="https://release.asteroidos.org/nightlies/{{.}}/logo.bin" role="button">logo.bin</a>


### PR DESCRIPTION
This pull request is a supporting pull request for https://github.com/AsteroidOS/meta-asteroid/pull/238, which changes the names of boot partitions. Correspondingly, this PR changes them here too.

For now, only basic support for these changes (e.g. renaming zImage-$MACHINE.fastboot to boot.img) is added to avoid breaking current watches. It is probably best to wait until we have a supported watch which utilises the extra partitions etc before deciding on how best to handle them here.